### PR TITLE
Merge roachperf into roachprod

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ $ go get -u github.com/cockroachlabs/roachprod
 * Default settings create 4 VMs (`-n 4`) with 4 CPUs, 15GB memory
   (`--machine-type=n1-standard-4`), and local SSDs (`--local-ssd`).
 
-## Cluster quick-start using roachprod/roachperf
+## Cluster quick-start using roachprod
 
 ```bash
 # Create a cluster with 4 nodes and local SSD. The last node is used as a
-# load generator by roachperf.
-# Note that the cluster name must always begin with your username.
+# load generator for some tests. Note that the cluster name must always begin
+# with your username.
 export FULLNAME="${USER}-test"
 roachprod create ${FULLNAME} -n 4 --local-ssd
 
@@ -43,11 +43,11 @@ ssh-add ~/.ssh/google_compute_engine
 crl-stage-binaries ${FULLNAME} all scripts
 crl-stage-binaries ${FULLNAME} all cockroach
 
-# ...or using roachperf (e.g., for your locally-built binary).
-roachperf ${FULLNAME} put cockroach
+# ...or using roachprod directly (e.g., for your locally-built binary).
+roachprod put ${FULLNAME} cockroach
 
-# Start a cluster using roachperf.
-roachperf ${FULLNAME} start
+# Start a cluster.
+roachprod start ${FULLNAME}
 
 # Check the admin UI.
 # http://35.196.94.196:8080
@@ -98,14 +98,13 @@ Filesystem      Size  Used Avail Use% Mounted on
 /dev/sda1        49G  1.2G   48G   3% /
 ```
 
-### Interact using `roachperf`
-[roachperf] also consumes `~/.roachprod/hosts`.
+### Interact using `roachprod` directly
 
 ```
 # Add ssh-key
 $ ssh-add ~/.ssh/google_compute_engine
 
-$ roachperf marc-foo status
+$ roachprod status marc-foo
 marc-foo: status 3/3
    1: not running
    2: not running
@@ -144,6 +143,15 @@ See `roachprod help <command>` for further details.
 
 * Bigger loadgen VM (last instance)
 
+* Ease the creation of test metadata and then running a series of tests
+  using `roachprod <cluster> test <dir1> <dir2> ...`. Perhaps something like
+  `roachprod prepare <test> <binary>`.
+
+* Automatically detect stalled tests and restart tests upon unexpected
+  failures. Detection of stalled tests could be done by noticing zero output
+  for a period of time.
+
+* Detect crashed cockroach nodes.
+
 [cockroach-ephemeral]: https://console.cloud.google.com/home/dashboard?project=cockroach-ephemeral
 [gcloud installed]: https://cloud.google.com/sdk/downloads
-[roachperf]: https://github.com/cockroachdb/roachperf

--- a/cassandra.go
+++ b/cassandra.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"html/template"
+	"io/ioutil"
+	"log"
+	"os"
+	"time"
+)
+
+type cassandra struct{}
+
+func (cassandra) start(c *syncedCluster) {
+	yamlPath, err := makeCassandraYAML(c)
+	if err != nil {
+		log.Fatal(err)
+	}
+	c.put(yamlPath, "./cassandra.yaml")
+	_ = os.Remove(yamlPath)
+
+	display := fmt.Sprintf("%s: starting cassandra (be patient)", c.name)
+	nodes := c.serverNodes()
+	c.parallel(display, len(nodes), 1, func(i int) ([]byte, error) {
+		host := c.host(nodes[i])
+		user := c.user(nodes[i])
+
+		if err := func() error {
+			session, err := newSSHSession(user, host)
+			if err != nil {
+				return err
+			}
+			defer session.Close()
+
+			cmd := c.env + ` cassandra` +
+				` -Dcassandra.config=file://${PWD}/cassandra.yaml` +
+				` -Dcassandra.ring_delay_ms=3000` +
+				` > cassandra.stdout 2> cassandra.stderr`
+			_, err = session.CombinedOutput(cmd)
+			return err
+		}(); err != nil {
+			return nil, err
+		}
+
+		for {
+			up, err := func() (bool, error) {
+				session, err := newSSHSession(user, host)
+				if err != nil {
+					return false, err
+				}
+				defer session.Close()
+
+				cmd := `nc -z $(hostname) 9042`
+				if _, err := session.CombinedOutput(cmd); err != nil {
+					return false, nil
+				}
+				return true, nil
+			}()
+			if err != nil {
+				return nil, err
+			}
+			if up {
+				break
+			}
+			time.Sleep(time.Second)
+		}
+		return nil, nil
+	})
+}
+
+func (cassandra) nodeURL(_ *syncedCluster, host string, port int) string {
+	return fmt.Sprintf("'cassandra://%s:%d'", host, port)
+}
+
+func (cassandra) nodePort(c *syncedCluster, index int) int {
+	if c.isLocal() {
+		// TODO(peter): This will require a bit of work to adjust ports in
+		// cassandra.yaml.
+	}
+	return 9042
+}
+
+func makeCassandraYAML(c *syncedCluster) (string, error) {
+	ip, err := c.getInternalIP(c.serverNodes()[0])
+	if err != nil {
+		return "", err
+	}
+
+	f, err := ioutil.TempFile("", "cassandra.yaml")
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	w := bufio.NewWriter(f)
+	w.WriteString(cassandraDefaultYAML)
+	defer w.Flush()
+
+	t, err := template.New("cassandra.yaml").Parse(cassandraDiffYAML)
+	if err != nil {
+		log.Fatal(err)
+	}
+	m := map[string]interface{}{
+		"Seeds": ip,
+	}
+	if err := t.Execute(w, m); err != nil {
+		log.Fatal(err)
+	}
+	return f.Name(), nil
+}

--- a/cassandra_yaml.go
+++ b/cassandra_yaml.go
@@ -1,0 +1,1267 @@
+package main
+
+const cassandraDiffYAML = `
+commitlog_sync: batch
+commitlog_sync_batch_window_in_ms: 2
+commitlog_sync_period_in_ms: 0
+
+read_request_timeout_in_ms: 10000
+write_request_timeout_in_ms: 10000
+
+commitlog_directory: /mnt/data1/cassandra/commitlog
+data_file_directories:
+    - /mnt/data1/cassandra/data
+hints_directory: /mnt/data1/cassandra/hints
+saved_caches_directory: /mnt/data1/cassandra/saved_caches
+
+seed_provider:
+    # Addresses of hosts that are deemed contact points.
+    # Cassandra nodes use this list of hosts to find each other and learn
+    # the topology of the ring.  You must change this if you are running
+    # multiple nodes!
+    - class_name: org.apache.cassandra.locator.SimpleSeedProvider
+      parameters:
+          # seeds is actually a comma-delimited list of addresses.
+          # Ex: "<ip1>,<ip2>,<ip3>"
+          - seeds: "{{.Seeds}}"
+`
+
+// Note: this is the default cassandra.yaml that ships with Cassandra
+// 3.11.1. Add overrides to cassandraDiffYAML instead of editing directly.
+//
+// The two edits below are to comment out listen_address and
+// rpc_address. Apparently those configs cannot be cleared once set.
+const cassandraDefaultYAML = `# Cassandra storage config YAML
+
+# NOTE:
+#   See http://wiki.apache.org/cassandra/StorageConfiguration for
+#   full explanations of configuration directives
+# /NOTE
+
+# The name of the cluster. This is mainly used to prevent machines in
+# one logical cluster from joining another.
+cluster_name: 'Test Cluster'
+
+# This defines the number of tokens randomly assigned to this node on the ring
+# The more tokens, relative to other nodes, the larger the proportion of data
+# that this node will store. You probably want all nodes to have the same number
+# of tokens assuming they have equal hardware capability.
+#
+# If you leave this unspecified, Cassandra will use the default of 1 token for legacy compatibility,
+# and will use the initial_token as described below.
+#
+# Specifying initial_token will override this setting on the node's initial start,
+# on subsequent starts, this setting will apply even if initial token is set.
+#
+# If you already have a cluster with 1 token per node, and wish to migrate to 
+# multiple tokens per node, see http://wiki.apache.org/cassandra/Operations
+num_tokens: 256
+
+# Triggers automatic allocation of num_tokens tokens for this node. The allocation
+# algorithm attempts to choose tokens in a way that optimizes replicated load over
+# the nodes in the datacenter for the replication strategy used by the specified
+# keyspace.
+#
+# The load assigned to each node will be close to proportional to its number of
+# vnodes.
+#
+# Only supported with the Murmur3Partitioner.
+# allocate_tokens_for_keyspace: KEYSPACE
+
+# initial_token allows you to specify tokens manually.  While you can use it with
+# vnodes (num_tokens > 1, above) -- in which case you should provide a 
+# comma-separated list -- it's primarily used when adding nodes to legacy clusters 
+# that do not have vnodes enabled.
+# initial_token:
+
+# See http://wiki.apache.org/cassandra/HintedHandoff
+# May either be "true" or "false" to enable globally
+hinted_handoff_enabled: true
+
+# When hinted_handoff_enabled is true, a black list of data centers that will not
+# perform hinted handoff
+# hinted_handoff_disabled_datacenters:
+#    - DC1
+#    - DC2
+
+# this defines the maximum amount of time a dead host will have hints
+# generated.  After it has been dead this long, new hints for it will not be
+# created until it has been seen alive and gone down again.
+max_hint_window_in_ms: 10800000 # 3 hours
+
+# Maximum throttle in KBs per second, per delivery thread.  This will be
+# reduced proportionally to the number of nodes in the cluster.  (If there
+# are two nodes in the cluster, each delivery thread will use the maximum
+# rate; if there are three, each will throttle to half of the maximum,
+# since we expect two nodes to be delivering hints simultaneously.)
+hinted_handoff_throttle_in_kb: 1024
+
+# Number of threads with which to deliver hints;
+# Consider increasing this number when you have multi-dc deployments, since
+# cross-dc handoff tends to be slower
+max_hints_delivery_threads: 2
+
+# Directory where Cassandra should store hints.
+# If not set, the default directory is $CASSANDRA_HOME/data/hints.
+# hints_directory: /var/lib/cassandra/hints
+
+# How often hints should be flushed from the internal buffers to disk.
+# Will *not* trigger fsync.
+hints_flush_period_in_ms: 10000
+
+# Maximum size for a single hints file, in megabytes.
+max_hints_file_size_in_mb: 128
+
+# Compression to apply to the hint files. If omitted, hints files
+# will be written uncompressed. LZ4, Snappy, and Deflate compressors
+# are supported.
+#hints_compression:
+#   - class_name: LZ4Compressor
+#     parameters:
+#         -
+
+# Maximum throttle in KBs per second, total. This will be
+# reduced proportionally to the number of nodes in the cluster.
+batchlog_replay_throttle_in_kb: 1024
+
+# Authentication backend, implementing IAuthenticator; used to identify users
+# Out of the box, Cassandra provides org.apache.cassandra.auth.{AllowAllAuthenticator,
+# PasswordAuthenticator}.
+#
+# - AllowAllAuthenticator performs no checks - set it to disable authentication.
+# - PasswordAuthenticator relies on username/password pairs to authenticate
+#   users. It keeps usernames and hashed passwords in system_auth.roles table.
+#   Please increase system_auth keyspace replication factor if you use this authenticator.
+#   If using PasswordAuthenticator, CassandraRoleManager must also be used (see below)
+authenticator: AllowAllAuthenticator
+
+# Authorization backend, implementing IAuthorizer; used to limit access/provide permissions
+# Out of the box, Cassandra provides org.apache.cassandra.auth.{AllowAllAuthorizer,
+# CassandraAuthorizer}.
+#
+# - AllowAllAuthorizer allows any action to any user - set it to disable authorization.
+# - CassandraAuthorizer stores permissions in system_auth.role_permissions table. Please
+#   increase system_auth keyspace replication factor if you use this authorizer.
+authorizer: AllowAllAuthorizer
+
+# Part of the Authentication & Authorization backend, implementing IRoleManager; used
+# to maintain grants and memberships between roles.
+# Out of the box, Cassandra provides org.apache.cassandra.auth.CassandraRoleManager,
+# which stores role information in the system_auth keyspace. Most functions of the
+# IRoleManager require an authenticated login, so unless the configured IAuthenticator
+# actually implements authentication, most of this functionality will be unavailable.
+#
+# - CassandraRoleManager stores role data in the system_auth keyspace. Please
+#   increase system_auth keyspace replication factor if you use this role manager.
+role_manager: CassandraRoleManager
+
+# Validity period for roles cache (fetching granted roles can be an expensive
+# operation depending on the role manager, CassandraRoleManager is one example)
+# Granted roles are cached for authenticated sessions in AuthenticatedUser and
+# after the period specified here, become eligible for (async) reload.
+# Defaults to 2000, set to 0 to disable caching entirely.
+# Will be disabled automatically for AllowAllAuthenticator.
+roles_validity_in_ms: 2000
+
+# Refresh interval for roles cache (if enabled).
+# After this interval, cache entries become eligible for refresh. Upon next
+# access, an async reload is scheduled and the old value returned until it
+# completes. If roles_validity_in_ms is non-zero, then this must be
+# also.
+# Defaults to the same value as roles_validity_in_ms.
+# roles_update_interval_in_ms: 2000
+
+# Validity period for permissions cache (fetching permissions can be an
+# expensive operation depending on the authorizer, CassandraAuthorizer is
+# one example). Defaults to 2000, set to 0 to disable.
+# Will be disabled automatically for AllowAllAuthorizer.
+permissions_validity_in_ms: 2000
+
+# Refresh interval for permissions cache (if enabled).
+# After this interval, cache entries become eligible for refresh. Upon next
+# access, an async reload is scheduled and the old value returned until it
+# completes. If permissions_validity_in_ms is non-zero, then this must be
+# also.
+# Defaults to the same value as permissions_validity_in_ms.
+# permissions_update_interval_in_ms: 2000
+
+# Validity period for credentials cache. This cache is tightly coupled to
+# the provided PasswordAuthenticator implementation of IAuthenticator. If
+# another IAuthenticator implementation is configured, this cache will not
+# be automatically used and so the following settings will have no effect.
+# Please note, credentials are cached in their encrypted form, so while
+# activating this cache may reduce the number of queries made to the
+# underlying table, it may not  bring a significant reduction in the
+# latency of individual authentication attempts.
+# Defaults to 2000, set to 0 to disable credentials caching.
+credentials_validity_in_ms: 2000
+
+# Refresh interval for credentials cache (if enabled).
+# After this interval, cache entries become eligible for refresh. Upon next
+# access, an async reload is scheduled and the old value returned until it
+# completes. If credentials_validity_in_ms is non-zero, then this must be
+# also.
+# Defaults to the same value as credentials_validity_in_ms.
+# credentials_update_interval_in_ms: 2000
+
+# The partitioner is responsible for distributing groups of rows (by
+# partition key) across nodes in the cluster.  You should leave this
+# alone for new clusters.  The partitioner can NOT be changed without
+# reloading all data, so when upgrading you should set this to the
+# same partitioner you were already using.
+#
+# Besides Murmur3Partitioner, partitioners included for backwards
+# compatibility include RandomPartitioner, ByteOrderedPartitioner, and
+# OrderPreservingPartitioner.
+#
+partitioner: org.apache.cassandra.dht.Murmur3Partitioner
+
+# Directories where Cassandra should store data on disk.  Cassandra
+# will spread data evenly across them, subject to the granularity of
+# the configured compaction strategy.
+# If not set, the default directory is $CASSANDRA_HOME/data/data.
+# data_file_directories:
+#     - /var/lib/cassandra/data
+
+# commit log.  when running on magnetic HDD, this should be a
+# separate spindle than the data directories.
+# If not set, the default directory is $CASSANDRA_HOME/data/commitlog.
+# commitlog_directory: /var/lib/cassandra/commitlog
+
+# Enable / disable CDC functionality on a per-node basis. This modifies the logic used
+# for write path allocation rejection (standard: never reject. cdc: reject Mutation
+# containing a CDC-enabled table if at space limit in cdc_raw_directory).
+cdc_enabled: false
+
+# CommitLogSegments are moved to this directory on flush if cdc_enabled: true and the
+# segment contains mutations for a CDC-enabled table. This should be placed on a
+# separate spindle than the data directories. If not set, the default directory is
+# $CASSANDRA_HOME/data/cdc_raw.
+# cdc_raw_directory: /var/lib/cassandra/cdc_raw
+
+# Policy for data disk failures:
+#
+# die
+#   shut down gossip and client transports and kill the JVM for any fs errors or
+#   single-sstable errors, so the node can be replaced.
+#
+# stop_paranoid
+#   shut down gossip and client transports even for single-sstable errors,
+#   kill the JVM for errors during startup.
+#
+# stop
+#   shut down gossip and client transports, leaving the node effectively dead, but
+#   can still be inspected via JMX, kill the JVM for errors during startup.
+#
+# best_effort
+#    stop using the failed disk and respond to requests based on
+#    remaining available sstables.  This means you WILL see obsolete
+#    data at CL.ONE!
+#
+# ignore
+#    ignore fatal errors and let requests fail, as in pre-1.2 Cassandra
+disk_failure_policy: stop
+
+# Policy for commit disk failures:
+#
+# die
+#   shut down gossip and Thrift and kill the JVM, so the node can be replaced.
+#
+# stop
+#   shut down gossip and Thrift, leaving the node effectively dead, but
+#   can still be inspected via JMX.
+#
+# stop_commit
+#   shutdown the commit log, letting writes collect but
+#   continuing to service reads, as in pre-2.0.5 Cassandra
+#
+# ignore
+#   ignore fatal errors and let the batches fail
+commit_failure_policy: stop
+
+# Maximum size of the native protocol prepared statement cache
+#
+# Valid values are either "auto" (omitting the value) or a value greater 0.
+#
+# Note that specifying a too large value will result in long running GCs and possbily
+# out-of-memory errors. Keep the value at a small fraction of the heap.
+#
+# If you constantly see "prepared statements discarded in the last minute because
+# cache limit reached" messages, the first step is to investigate the root cause
+# of these messages and check whether prepared statements are used correctly -
+# i.e. use bind markers for variable parts.
+#
+# Do only change the default value, if you really have more prepared statements than
+# fit in the cache. In most cases it is not neccessary to change this value.
+# Constantly re-preparing statements is a performance penalty.
+#
+# Default value ("auto") is 1/256th of the heap or 10MB, whichever is greater
+prepared_statements_cache_size_mb:
+
+# Maximum size of the Thrift prepared statement cache
+#
+# If you do not use Thrift at all, it is safe to leave this value at "auto".
+#
+# See description of 'prepared_statements_cache_size_mb' above for more information.
+#
+# Default value ("auto") is 1/256th of the heap or 10MB, whichever is greater
+thrift_prepared_statements_cache_size_mb:
+
+# Maximum size of the key cache in memory.
+#
+# Each key cache hit saves 1 seek and each row cache hit saves 2 seeks at the
+# minimum, sometimes more. The key cache is fairly tiny for the amount of
+# time it saves, so it's worthwhile to use it at large numbers.
+# The row cache saves even more time, but must contain the entire row,
+# so it is extremely space-intensive. It's best to only use the
+# row cache if you have hot rows or static rows.
+#
+# NOTE: if you reduce the size, you may not get you hottest keys loaded on startup.
+#
+# Default value is empty to make it "auto" (min(5% of Heap (in MB), 100MB)). Set to 0 to disable key cache.
+key_cache_size_in_mb:
+
+# Duration in seconds after which Cassandra should
+# save the key cache. Caches are saved to saved_caches_directory as
+# specified in this configuration file.
+#
+# Saved caches greatly improve cold-start speeds, and is relatively cheap in
+# terms of I/O for the key cache. Row cache saving is much more expensive and
+# has limited use.
+#
+# Default is 14400 or 4 hours.
+key_cache_save_period: 14400
+
+# Number of keys from the key cache to save
+# Disabled by default, meaning all keys are going to be saved
+# key_cache_keys_to_save: 100
+
+# Row cache implementation class name. Available implementations:
+#
+# org.apache.cassandra.cache.OHCProvider
+#   Fully off-heap row cache implementation (default).
+#
+# org.apache.cassandra.cache.SerializingCacheProvider
+#   This is the row cache implementation availabile
+#   in previous releases of Cassandra.
+# row_cache_class_name: org.apache.cassandra.cache.OHCProvider
+
+# Maximum size of the row cache in memory.
+# Please note that OHC cache implementation requires some additional off-heap memory to manage
+# the map structures and some in-flight memory during operations before/after cache entries can be
+# accounted against the cache capacity. This overhead is usually small compared to the whole capacity.
+# Do not specify more memory that the system can afford in the worst usual situation and leave some
+# headroom for OS block level cache. Do never allow your system to swap.
+#
+# Default value is 0, to disable row caching.
+row_cache_size_in_mb: 0
+
+# Duration in seconds after which Cassandra should save the row cache.
+# Caches are saved to saved_caches_directory as specified in this configuration file.
+#
+# Saved caches greatly improve cold-start speeds, and is relatively cheap in
+# terms of I/O for the key cache. Row cache saving is much more expensive and
+# has limited use.
+#
+# Default is 0 to disable saving the row cache.
+row_cache_save_period: 0
+
+# Number of keys from the row cache to save.
+# Specify 0 (which is the default), meaning all keys are going to be saved
+# row_cache_keys_to_save: 100
+
+# Maximum size of the counter cache in memory.
+#
+# Counter cache helps to reduce counter locks' contention for hot counter cells.
+# In case of RF = 1 a counter cache hit will cause Cassandra to skip the read before
+# write entirely. With RF > 1 a counter cache hit will still help to reduce the duration
+# of the lock hold, helping with hot counter cell updates, but will not allow skipping
+# the read entirely. Only the local (clock, count) tuple of a counter cell is kept
+# in memory, not the whole counter, so it's relatively cheap.
+#
+# NOTE: if you reduce the size, you may not get you hottest keys loaded on startup.
+#
+# Default value is empty to make it "auto" (min(2.5% of Heap (in MB), 50MB)). Set to 0 to disable counter cache.
+# NOTE: if you perform counter deletes and rely on low gcgs, you should disable the counter cache.
+counter_cache_size_in_mb:
+
+# Duration in seconds after which Cassandra should
+# save the counter cache (keys only). Caches are saved to saved_caches_directory as
+# specified in this configuration file.
+#
+# Default is 7200 or 2 hours.
+counter_cache_save_period: 7200
+
+# Number of keys from the counter cache to save
+# Disabled by default, meaning all keys are going to be saved
+# counter_cache_keys_to_save: 100
+
+# saved caches
+# If not set, the default directory is $CASSANDRA_HOME/data/saved_caches.
+# saved_caches_directory: /var/lib/cassandra/saved_caches
+
+# commitlog_sync may be either "periodic" or "batch." 
+# 
+# When in batch mode, Cassandra won't ack writes until the commit log
+# has been fsynced to disk.  It will wait
+# commitlog_sync_batch_window_in_ms milliseconds between fsyncs.
+# This window should be kept short because the writer threads will
+# be unable to do extra work while waiting.  (You may need to increase
+# concurrent_writes for the same reason.)
+#
+# commitlog_sync: batch
+# commitlog_sync_batch_window_in_ms: 2
+#
+# the other option is "periodic" where writes may be acked immediately
+# and the CommitLog is simply synced every commitlog_sync_period_in_ms
+# milliseconds. 
+commitlog_sync: periodic
+commitlog_sync_period_in_ms: 10000
+
+# The size of the individual commitlog file segments.  A commitlog
+# segment may be archived, deleted, or recycled once all the data
+# in it (potentially from each columnfamily in the system) has been
+# flushed to sstables.
+#
+# The default size is 32, which is almost always fine, but if you are
+# archiving commitlog segments (see commitlog_archiving.properties),
+# then you probably want a finer granularity of archiving; 8 or 16 MB
+# is reasonable.
+# Max mutation size is also configurable via max_mutation_size_in_kb setting in
+# cassandra.yaml. The default is half the size commitlog_segment_size_in_mb * 1024.
+# This should be positive and less than 2048.
+#
+# NOTE: If max_mutation_size_in_kb is set explicitly then commitlog_segment_size_in_mb must
+# be set to at least twice the size of max_mutation_size_in_kb / 1024
+#
+commitlog_segment_size_in_mb: 32
+
+# Compression to apply to the commit log. If omitted, the commit log
+# will be written uncompressed.  LZ4, Snappy, and Deflate compressors
+# are supported.
+# commitlog_compression:
+#   - class_name: LZ4Compressor
+#     parameters:
+#         -
+
+# any class that implements the SeedProvider interface and has a
+# constructor that takes a Map<String, String> of parameters will do.
+seed_provider:
+    # Addresses of hosts that are deemed contact points. 
+    # Cassandra nodes use this list of hosts to find each other and learn
+    # the topology of the ring.  You must change this if you are running
+    # multiple nodes!
+    - class_name: org.apache.cassandra.locator.SimpleSeedProvider
+      parameters:
+          # seeds is actually a comma-delimited list of addresses.
+          # Ex: "<ip1>,<ip2>,<ip3>"
+          - seeds: "127.0.0.1"
+
+# For workloads with more data than can fit in memory, Cassandra's
+# bottleneck will be reads that need to fetch data from
+# disk. "concurrent_reads" should be set to (16 * number_of_drives) in
+# order to allow the operations to enqueue low enough in the stack
+# that the OS and drives can reorder them. Same applies to
+# "concurrent_counter_writes", since counter writes read the current
+# values before incrementing and writing them back.
+#
+# On the other hand, since writes are almost never IO bound, the ideal
+# number of "concurrent_writes" is dependent on the number of cores in
+# your system; (8 * number_of_cores) is a good rule of thumb.
+concurrent_reads: 32
+concurrent_writes: 32
+concurrent_counter_writes: 32
+
+# For materialized view writes, as there is a read involved, so this should
+# be limited by the less of concurrent reads or concurrent writes.
+concurrent_materialized_view_writes: 32
+
+# Maximum memory to use for sstable chunk cache and buffer pooling.
+# 32MB of this are reserved for pooling buffers, the rest is used as an
+# cache that holds uncompressed sstable chunks.
+# Defaults to the smaller of 1/4 of heap or 512MB. This pool is allocated off-heap,
+# so is in addition to the memory allocated for heap. The cache also has on-heap
+# overhead which is roughly 128 bytes per chunk (i.e. 0.2% of the reserved size
+# if the default 64k chunk size is used).
+# Memory is only allocated when needed.
+# file_cache_size_in_mb: 512
+
+# Flag indicating whether to allocate on or off heap when the sstable buffer
+# pool is exhausted, that is when it has exceeded the maximum memory
+# file_cache_size_in_mb, beyond which it will not cache buffers but allocate on request.
+
+# buffer_pool_use_heap_if_exhausted: true
+
+# The strategy for optimizing disk read
+# Possible values are:
+# ssd (for solid state disks, the default)
+# spinning (for spinning disks)
+# disk_optimization_strategy: ssd
+
+# Total permitted memory to use for memtables. Cassandra will stop
+# accepting writes when the limit is exceeded until a flush completes,
+# and will trigger a flush based on memtable_cleanup_threshold
+# If omitted, Cassandra will set both to 1/4 the size of the heap.
+# memtable_heap_space_in_mb: 2048
+# memtable_offheap_space_in_mb: 2048
+
+# memtable_cleanup_threshold is deprecated. The default calculation
+# is the only reasonable choice. See the comments on  memtable_flush_writers
+# for more information.
+#
+# Ratio of occupied non-flushing memtable size to total permitted size
+# that will trigger a flush of the largest memtable. Larger mct will
+# mean larger flushes and hence less compaction, but also less concurrent
+# flush activity which can make it difficult to keep your disks fed
+# under heavy write load.
+#
+# memtable_cleanup_threshold defaults to 1 / (memtable_flush_writers + 1)
+# memtable_cleanup_threshold: 0.11
+
+# Specify the way Cassandra allocates and manages memtable memory.
+# Options are:
+#
+# heap_buffers
+#   on heap nio buffers
+#
+# offheap_buffers
+#   off heap (direct) nio buffers
+#
+# offheap_objects
+#    off heap objects
+memtable_allocation_type: heap_buffers
+
+# Total space to use for commit logs on disk.
+#
+# If space gets above this value, Cassandra will flush every dirty CF
+# in the oldest segment and remove it.  So a small total commitlog space
+# will tend to cause more flush activity on less-active columnfamilies.
+#
+# The default value is the smaller of 8192, and 1/4 of the total space
+# of the commitlog volume.
+#
+# commitlog_total_space_in_mb: 8192
+
+# This sets the number of memtable flush writer threads per disk
+# as well as the total number of memtables that can be flushed concurrently.
+# These are generally a combination of compute and IO bound.
+#
+# Memtable flushing is more CPU efficient than memtable ingest and a single thread
+# can keep up with the ingest rate of a whole server on a single fast disk
+# until it temporarily becomes IO bound under contention typically with compaction.
+# At that point you need multiple flush threads. At some point in the future
+# it may become CPU bound all the time.
+#
+# You can tell if flushing is falling behind using the MemtablePool.BlockedOnAllocation
+# metric which should be 0, but will be non-zero if threads are blocked waiting on flushing
+# to free memory.
+#
+# memtable_flush_writers defaults to two for a single data directory.
+# This means that two  memtables can be flushed concurrently to the single data directory.
+# If you have multiple data directories the default is one memtable flushing at a time
+# but the flush will use a thread per data directory so you will get two or more writers.
+#
+# Two is generally enough to flush on a fast disk [array] mounted as a single data directory.
+# Adding more flush writers will result in smaller more frequent flushes that introduce more
+# compaction overhead.
+#
+# There is a direct tradeoff between number of memtables that can be flushed concurrently
+# and flush size and frequency. More is not better you just need enough flush writers
+# to never stall waiting for flushing to free memory.
+#
+#memtable_flush_writers: 2
+
+# Total space to use for change-data-capture logs on disk.
+#
+# If space gets above this value, Cassandra will throw WriteTimeoutException
+# on Mutations including tables with CDC enabled. A CDCCompactor is responsible
+# for parsing the raw CDC logs and deleting them when parsing is completed.
+#
+# The default value is the min of 4096 mb and 1/8th of the total space
+# of the drive where cdc_raw_directory resides.
+# cdc_total_space_in_mb: 4096
+
+# When we hit our cdc_raw limit and the CDCCompactor is either running behind
+# or experiencing backpressure, we check at the following interval to see if any
+# new space for cdc-tracked tables has been made available. Default to 250ms
+# cdc_free_space_check_interval_ms: 250
+
+# A fixed memory pool size in MB for for SSTable index summaries. If left
+# empty, this will default to 5% of the heap size. If the memory usage of
+# all index summaries exceeds this limit, SSTables with low read rates will
+# shrink their index summaries in order to meet this limit.  However, this
+# is a best-effort process. In extreme conditions Cassandra may need to use
+# more than this amount of memory.
+index_summary_capacity_in_mb:
+
+# How frequently index summaries should be resampled.  This is done
+# periodically to redistribute memory from the fixed-size pool to sstables
+# proportional their recent read rates.  Setting to -1 will disable this
+# process, leaving existing index summaries at their current sampling level.
+index_summary_resize_interval_in_minutes: 60
+
+# Whether to, when doing sequential writing, fsync() at intervals in
+# order to force the operating system to flush the dirty
+# buffers. Enable this to avoid sudden dirty buffer flushing from
+# impacting read latencies. Almost always a good idea on SSDs; not
+# necessarily on platters.
+trickle_fsync: false
+trickle_fsync_interval_in_kb: 10240
+
+# TCP port, for commands and data
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+storage_port: 7000
+
+# SSL port, for encrypted communication.  Unused unless enabled in
+# encryption_options
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+ssl_storage_port: 7001
+
+# Address or interface to bind to and tell other Cassandra nodes to connect to.
+# You _must_ change this if you want multiple nodes to be able to communicate!
+#
+# Set listen_address OR listen_interface, not both.
+#
+# Leaving it blank leaves it up to InetAddress.getLocalHost(). This
+# will always do the Right Thing _if_ the node is properly configured
+# (hostname, name resolution, etc), and the Right Thing is to use the
+# address associated with the hostname (it might not be).
+#
+# Setting listen_address to 0.0.0.0 is always wrong.
+#
+# listen_address: localhost
+
+# Set listen_address OR listen_interface, not both. Interfaces must correspond
+# to a single address, IP aliasing is not supported.
+# listen_interface: eth0
+
+# If you choose to specify the interface by name and the interface has an ipv4 and an ipv6 address
+# you can specify which should be chosen using listen_interface_prefer_ipv6. If false the first ipv4
+# address will be used. If true the first ipv6 address will be used. Defaults to false preferring
+# ipv4. If there is only one address it will be selected regardless of ipv4/ipv6.
+# listen_interface_prefer_ipv6: false
+
+# Address to broadcast to other Cassandra nodes
+# Leaving this blank will set it to the same value as listen_address
+# broadcast_address: 1.2.3.4
+
+# When using multiple physical network interfaces, set this
+# to true to listen on broadcast_address in addition to
+# the listen_address, allowing nodes to communicate in both
+# interfaces.
+# Ignore this property if the network configuration automatically
+# routes  between the public and private networks such as EC2.
+# listen_on_broadcast_address: false
+
+# Internode authentication backend, implementing IInternodeAuthenticator;
+# used to allow/disallow connections from peer nodes.
+# internode_authenticator: org.apache.cassandra.auth.AllowAllInternodeAuthenticator
+
+# Whether to start the native transport server.
+# Please note that the address on which the native transport is bound is the
+# same as the rpc_address. The port however is different and specified below.
+start_native_transport: true
+# port for the CQL native transport to listen for clients on
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+native_transport_port: 9042
+# Enabling native transport encryption in client_encryption_options allows you to either use
+# encryption for the standard port or to use a dedicated, additional port along with the unencrypted
+# standard native_transport_port.
+# Enabling client encryption and keeping native_transport_port_ssl disabled will use encryption
+# for native_transport_port. Setting native_transport_port_ssl to a different value
+# from native_transport_port will use encryption for native_transport_port_ssl while
+# keeping native_transport_port unencrypted.
+# native_transport_port_ssl: 9142
+# The maximum threads for handling requests when the native transport is used.
+# This is similar to rpc_max_threads though the default differs slightly (and
+# there is no native_transport_min_threads, idle threads will always be stopped
+# after 30 seconds).
+# native_transport_max_threads: 128
+#
+# The maximum size of allowed frame. Frame (requests) larger than this will
+# be rejected as invalid. The default is 256MB. If you're changing this parameter,
+# you may want to adjust max_value_size_in_mb accordingly. This should be positive and less than 2048.
+# native_transport_max_frame_size_in_mb: 256
+
+# The maximum number of concurrent client connections.
+# The default is -1, which means unlimited.
+# native_transport_max_concurrent_connections: -1
+
+# The maximum number of concurrent client connections per source ip.
+# The default is -1, which means unlimited.
+# native_transport_max_concurrent_connections_per_ip: -1
+
+# Whether to start the thrift rpc server.
+start_rpc: false
+
+# The address or interface to bind the Thrift RPC service and native transport
+# server to.
+#
+# Set rpc_address OR rpc_interface, not both.
+#
+# Leaving rpc_address blank has the same effect as on listen_address
+# (i.e. it will be based on the configured hostname of the node).
+#
+# Note that unlike listen_address, you can specify 0.0.0.0, but you must also
+# set broadcast_rpc_address to a value other than 0.0.0.0.
+#
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+# rpc_address: localhost
+
+# Set rpc_address OR rpc_interface, not both. Interfaces must correspond
+# to a single address, IP aliasing is not supported.
+# rpc_interface: eth1
+
+# If you choose to specify the interface by name and the interface has an ipv4 and an ipv6 address
+# you can specify which should be chosen using rpc_interface_prefer_ipv6. If false the first ipv4
+# address will be used. If true the first ipv6 address will be used. Defaults to false preferring
+# ipv4. If there is only one address it will be selected regardless of ipv4/ipv6.
+# rpc_interface_prefer_ipv6: false
+
+# port for Thrift to listen for clients on
+rpc_port: 9160
+
+# RPC address to broadcast to drivers and other Cassandra nodes. This cannot
+# be set to 0.0.0.0. If left blank, this will be set to the value of
+# rpc_address. If rpc_address is set to 0.0.0.0, broadcast_rpc_address must
+# be set.
+# broadcast_rpc_address: 1.2.3.4
+
+# enable or disable keepalive on rpc/native connections
+rpc_keepalive: true
+
+# Cassandra provides two out-of-the-box options for the RPC Server:
+#
+# sync
+#   One thread per thrift connection. For a very large number of clients, memory
+#   will be your limiting factor. On a 64 bit JVM, 180KB is the minimum stack size
+#   per thread, and that will correspond to your use of virtual memory (but physical memory
+#   may be limited depending on use of stack space).
+#
+# hsha
+#   Stands for "half synchronous, half asynchronous." All thrift clients are handled
+#   asynchronously using a small number of threads that does not vary with the amount
+#   of thrift clients (and thus scales well to many clients). The rpc requests are still
+#   synchronous (one thread per active request). If hsha is selected then it is essential
+#   that rpc_max_threads is changed from the default value of unlimited.
+#
+# The default is sync because on Windows hsha is about 30% slower.  On Linux,
+# sync/hsha performance is about the same, with hsha of course using less memory.
+#
+# Alternatively,  can provide your own RPC server by providing the fully-qualified class name
+# of an o.a.c.t.TServerFactory that can create an instance of it.
+rpc_server_type: sync
+
+# Uncomment rpc_min|max_thread to set request pool size limits.
+#
+# Regardless of your choice of RPC server (see above), the number of maximum requests in the
+# RPC thread pool dictates how many concurrent requests are possible (but if you are using the sync
+# RPC server, it also dictates the number of clients that can be connected at all).
+#
+# The default is unlimited and thus provides no protection against clients overwhelming the server. You are
+# encouraged to set a maximum that makes sense for you in production, but do keep in mind that
+# rpc_max_threads represents the maximum number of client requests this server may execute concurrently.
+#
+# rpc_min_threads: 16
+# rpc_max_threads: 2048
+
+# uncomment to set socket buffer sizes on rpc connections
+# rpc_send_buff_size_in_bytes:
+# rpc_recv_buff_size_in_bytes:
+
+# Uncomment to set socket buffer size for internode communication
+# Note that when setting this, the buffer size is limited by net.core.wmem_max
+# and when not setting it it is defined by net.ipv4.tcp_wmem
+# See also:
+# /proc/sys/net/core/wmem_max
+# /proc/sys/net/core/rmem_max
+# /proc/sys/net/ipv4/tcp_wmem
+# /proc/sys/net/ipv4/tcp_wmem
+# and 'man tcp'
+# internode_send_buff_size_in_bytes:
+
+# Uncomment to set socket buffer size for internode communication
+# Note that when setting this, the buffer size is limited by net.core.wmem_max
+# and when not setting it it is defined by net.ipv4.tcp_wmem
+# internode_recv_buff_size_in_bytes:
+
+# Frame size for thrift (maximum message length).
+thrift_framed_transport_size_in_mb: 15
+
+# Set to true to have Cassandra create a hard link to each sstable
+# flushed or streamed locally in a backups/ subdirectory of the
+# keyspace data.  Removing these links is the operator's
+# responsibility.
+incremental_backups: false
+
+# Whether or not to take a snapshot before each compaction.  Be
+# careful using this option, since Cassandra won't clean up the
+# snapshots for you.  Mostly useful if you're paranoid when there
+# is a data format change.
+snapshot_before_compaction: false
+
+# Whether or not a snapshot is taken of the data before keyspace truncation
+# or dropping of column families. The STRONGLY advised default of true 
+# should be used to provide data safety. If you set this flag to false, you will
+# lose data on truncation or drop.
+auto_snapshot: true
+
+# Granularity of the collation index of rows within a partition.
+# Increase if your rows are large, or if you have a very large
+# number of rows per partition.  The competing goals are these:
+#
+# - a smaller granularity means more index entries are generated
+#   and looking up rows withing the partition by collation column
+#   is faster
+# - but, Cassandra will keep the collation index in memory for hot
+#   rows (as part of the key cache), so a larger granularity means
+#   you can cache more hot rows
+column_index_size_in_kb: 64
+
+# Per sstable indexed key cache entries (the collation index in memory
+# mentioned above) exceeding this size will not be held on heap.
+# This means that only partition information is held on heap and the
+# index entries are read from disk.
+#
+# Note that this size refers to the size of the
+# serialized index information and not the size of the partition.
+column_index_cache_size_in_kb: 2
+
+# Number of simultaneous compactions to allow, NOT including
+# validation "compactions" for anti-entropy repair.  Simultaneous
+# compactions can help preserve read performance in a mixed read/write
+# workload, by mitigating the tendency of small sstables to accumulate
+# during a single long running compactions. The default is usually
+# fine and if you experience problems with compaction running too
+# slowly or too fast, you should look at
+# compaction_throughput_mb_per_sec first.
+#
+# concurrent_compactors defaults to the smaller of (number of disks,
+# number of cores), with a minimum of 2 and a maximum of 8.
+# 
+# If your data directories are backed by SSD, you should increase this
+# to the number of cores.
+#concurrent_compactors: 1
+
+# Throttles compaction to the given total throughput across the entire
+# system. The faster you insert data, the faster you need to compact in
+# order to keep the sstable count down, but in general, setting this to
+# 16 to 32 times the rate you are inserting data is more than sufficient.
+# Setting this to 0 disables throttling. Note that this account for all types
+# of compaction, including validation compaction.
+compaction_throughput_mb_per_sec: 16
+
+# When compacting, the replacement sstable(s) can be opened before they
+# are completely written, and used in place of the prior sstables for
+# any range that has been written. This helps to smoothly transfer reads 
+# between the sstables, reducing page cache churn and keeping hot rows hot
+sstable_preemptive_open_interval_in_mb: 50
+
+# Throttles all outbound streaming file transfers on this node to the
+# given total throughput in Mbps. This is necessary because Cassandra does
+# mostly sequential IO when streaming data during bootstrap or repair, which
+# can lead to saturating the network connection and degrading rpc performance.
+# When unset, the default is 200 Mbps or 25 MB/s.
+# stream_throughput_outbound_megabits_per_sec: 200
+
+# Throttles all streaming file transfer between the datacenters,
+# this setting allows users to throttle inter dc stream throughput in addition
+# to throttling all network stream traffic as configured with
+# stream_throughput_outbound_megabits_per_sec
+# When unset, the default is 200 Mbps or 25 MB/s
+# inter_dc_stream_throughput_outbound_megabits_per_sec: 200
+
+# How long the coordinator should wait for read operations to complete
+read_request_timeout_in_ms: 5000
+# How long the coordinator should wait for seq or index scans to complete
+range_request_timeout_in_ms: 10000
+# How long the coordinator should wait for writes to complete
+write_request_timeout_in_ms: 2000
+# How long the coordinator should wait for counter writes to complete
+counter_write_request_timeout_in_ms: 5000
+# How long a coordinator should continue to retry a CAS operation
+# that contends with other proposals for the same row
+cas_contention_timeout_in_ms: 1000
+# How long the coordinator should wait for truncates to complete
+# (This can be much longer, because unless auto_snapshot is disabled
+# we need to flush first so we can snapshot before removing the data.)
+truncate_request_timeout_in_ms: 60000
+# The default timeout for other, miscellaneous operations
+request_timeout_in_ms: 10000
+
+# How long before a node logs slow queries. Select queries that take longer than
+# this timeout to execute, will generate an aggregated log message, so that slow queries
+# can be identified. Set this value to zero to disable slow query logging.
+slow_query_log_timeout_in_ms: 500
+
+# Enable operation timeout information exchange between nodes to accurately
+# measure request timeouts.  If disabled, replicas will assume that requests
+# were forwarded to them instantly by the coordinator, which means that
+# under overload conditions we will waste that much extra time processing 
+# already-timed-out requests.
+#
+# Warning: before enabling this property make sure to ntp is installed
+# and the times are synchronized between the nodes.
+cross_node_timeout: false
+
+# Set keep-alive period for streaming
+# This node will send a keep-alive message periodically with this period.
+# If the node does not receive a keep-alive message from the peer for
+# 2 keep-alive cycles the stream session times out and fail
+# Default value is 300s (5 minutes), which means stalled stream
+# times out in 10 minutes by default
+# streaming_keep_alive_period_in_secs: 300
+
+# phi value that must be reached for a host to be marked down.
+# most users should never need to adjust this.
+# phi_convict_threshold: 8
+
+# endpoint_snitch -- Set this to a class that implements
+# IEndpointSnitch.  The snitch has two functions:
+#
+# - it teaches Cassandra enough about your network topology to route
+#   requests efficiently
+# - it allows Cassandra to spread replicas around your cluster to avoid
+#   correlated failures. It does this by grouping machines into
+#   "datacenters" and "racks."  Cassandra will do its best not to have
+#   more than one replica on the same "rack" (which may not actually
+#   be a physical location)
+#
+# CASSANDRA WILL NOT ALLOW YOU TO SWITCH TO AN INCOMPATIBLE SNITCH
+# ONCE DATA IS INSERTED INTO THE CLUSTER.  This would cause data loss.
+# This means that if you start with the default SimpleSnitch, which
+# locates every node on "rack1" in "datacenter1", your only options
+# if you need to add another datacenter are GossipingPropertyFileSnitch
+# (and the older PFS).  From there, if you want to migrate to an
+# incompatible snitch like Ec2Snitch you can do it by adding new nodes
+# under Ec2Snitch (which will locate them in a new "datacenter") and
+# decommissioning the old ones.
+#
+# Out of the box, Cassandra provides:
+#
+# SimpleSnitch:
+#    Treats Strategy order as proximity. This can improve cache
+#    locality when disabling read repair.  Only appropriate for
+#    single-datacenter deployments.
+#
+# GossipingPropertyFileSnitch
+#    This should be your go-to snitch for production use.  The rack
+#    and datacenter for the local node are defined in
+#    cassandra-rackdc.properties and propagated to other nodes via
+#    gossip.  If cassandra-topology.properties exists, it is used as a
+#    fallback, allowing migration from the PropertyFileSnitch.
+#
+# PropertyFileSnitch:
+#    Proximity is determined by rack and data center, which are
+#    explicitly configured in cassandra-topology.properties.
+#
+# Ec2Snitch:
+#    Appropriate for EC2 deployments in a single Region. Loads Region
+#    and Availability Zone information from the EC2 API. The Region is
+#    treated as the datacenter, and the Availability Zone as the rack.
+#    Only private IPs are used, so this will not work across multiple
+#    Regions.
+#
+# Ec2MultiRegionSnitch:
+#    Uses public IPs as broadcast_address to allow cross-region
+#    connectivity.  (Thus, you should set seed addresses to the public
+#    IP as well.) You will need to open the storage_port or
+#    ssl_storage_port on the public IP firewall.  (For intra-Region
+#    traffic, Cassandra will switch to the private IP after
+#    establishing a connection.)
+#
+# RackInferringSnitch:
+#    Proximity is determined by rack and data center, which are
+#    assumed to correspond to the 3rd and 2nd octet of each node's IP
+#    address, respectively.  Unless this happens to match your
+#    deployment conventions, this is best used as an example of
+#    writing a custom Snitch class and is provided in that spirit.
+#
+# You can use a custom Snitch by setting this to the full class name
+# of the snitch, which will be assumed to be on your classpath.
+endpoint_snitch: SimpleSnitch
+
+# controls how often to perform the more expensive part of host score
+# calculation
+dynamic_snitch_update_interval_in_ms: 100 
+# controls how often to reset all host scores, allowing a bad host to
+# possibly recover
+dynamic_snitch_reset_interval_in_ms: 600000
+# if set greater than zero and read_repair_chance is < 1.0, this will allow
+# 'pinning' of replicas to hosts in order to increase cache capacity.
+# The badness threshold will control how much worse the pinned host has to be
+# before the dynamic snitch will prefer other replicas over it.  This is
+# expressed as a double which represents a percentage.  Thus, a value of
+# 0.2 means Cassandra would continue to prefer the static snitch values
+# until the pinned host was 20% worse than the fastest.
+dynamic_snitch_badness_threshold: 0.1
+
+# request_scheduler -- Set this to a class that implements
+# RequestScheduler, which will schedule incoming client requests
+# according to the specific policy. This is useful for multi-tenancy
+# with a single Cassandra cluster.
+# NOTE: This is specifically for requests from the client and does
+# not affect inter node communication.
+# org.apache.cassandra.scheduler.NoScheduler - No scheduling takes place
+# org.apache.cassandra.scheduler.RoundRobinScheduler - Round robin of
+# client requests to a node with a separate queue for each
+# request_scheduler_id. The scheduler is further customized by
+# request_scheduler_options as described below.
+request_scheduler: org.apache.cassandra.scheduler.NoScheduler
+
+# Scheduler Options vary based on the type of scheduler
+#
+# NoScheduler
+#   Has no options
+#
+# RoundRobin
+#   throttle_limit
+#     The throttle_limit is the number of in-flight
+#     requests per client.  Requests beyond 
+#     that limit are queued up until
+#     running requests can complete.
+#     The value of 80 here is twice the number of
+#     concurrent_reads + concurrent_writes.
+#   default_weight
+#     default_weight is optional and allows for
+#     overriding the default which is 1.
+#   weights
+#     Weights are optional and will default to 1 or the
+#     overridden default_weight. The weight translates into how
+#     many requests are handled during each turn of the
+#     RoundRobin, based on the scheduler id.
+#
+# request_scheduler_options:
+#    throttle_limit: 80
+#    default_weight: 5
+#    weights:
+#      Keyspace1: 1
+#      Keyspace2: 5
+
+# request_scheduler_id -- An identifier based on which to perform
+# the request scheduling. Currently the only valid option is keyspace.
+# request_scheduler_id: keyspace
+
+# Enable or disable inter-node encryption
+# JVM defaults for supported SSL socket protocols and cipher suites can
+# be replaced using custom encryption options. This is not recommended
+# unless you have policies in place that dictate certain settings, or
+# need to disable vulnerable ciphers or protocols in case the JVM cannot
+# be updated.
+# FIPS compliant settings can be configured at JVM level and should not
+# involve changing encryption settings here:
+# https://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/FIPS.html
+# *NOTE* No custom encryption options are enabled at the moment
+# The available internode options are : all, none, dc, rack
+#
+# If set to dc cassandra will encrypt the traffic between the DCs
+# If set to rack cassandra will encrypt the traffic between the racks
+#
+# The passwords used in these options must match the passwords used when generating
+# the keystore and truststore.  For instructions on generating these files, see:
+# http://download.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html#CreateKeystore
+#
+server_encryption_options:
+    internode_encryption: none
+    keystore: conf/.keystore
+    keystore_password: cassandra
+    truststore: conf/.truststore
+    truststore_password: cassandra
+    # More advanced defaults below:
+    # protocol: TLS
+    # algorithm: SunX509
+    # store_type: JKS
+    # cipher_suites: [TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA]
+    # require_client_auth: false
+    # require_endpoint_verification: false
+
+# enable or disable client/server encryption.
+client_encryption_options:
+    enabled: false
+    # If enabled and optional is set to true encrypted and unencrypted connections are handled.
+    optional: false
+    keystore: conf/.keystore
+    keystore_password: cassandra
+    # require_client_auth: false
+    # Set trustore and truststore_password if require_client_auth is true
+    # truststore: conf/.truststore
+    # truststore_password: cassandra
+    # More advanced defaults below:
+    # protocol: TLS
+    # algorithm: SunX509
+    # store_type: JKS
+    # cipher_suites: [TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA]
+
+# internode_compression controls whether traffic between nodes is
+# compressed.
+# Can be:
+#
+# all
+#   all traffic is compressed
+#
+# dc
+#   traffic between different datacenters is compressed
+#
+# none
+#   nothing is compressed.
+internode_compression: dc
+
+# Enable or disable tcp_nodelay for inter-dc communication.
+# Disabling it will result in larger (but fewer) network packets being sent,
+# reducing overhead from the TCP protocol itself, at the cost of increasing
+# latency if you block for cross-datacenter responses.
+inter_dc_tcp_nodelay: false
+
+# TTL for different trace types used during logging of the repair process.
+tracetype_query_ttl: 86400
+tracetype_repair_ttl: 604800
+
+# By default, Cassandra logs GC Pauses greater than 200 ms at INFO level
+# This threshold can be adjusted to minimize logging if necessary
+# gc_log_threshold_in_ms: 200
+
+# If unset, all GC Pauses greater than gc_log_threshold_in_ms will log at
+# INFO level
+# UDFs (user defined functions) are disabled by default.
+# As of Cassandra 3.0 there is a sandbox in place that should prevent execution of evil code.
+enable_user_defined_functions: false
+
+# Enables scripted UDFs (JavaScript UDFs).
+# Java UDFs are always enabled, if enable_user_defined_functions is true.
+# Enable this option to be able to use UDFs with "language javascript" or any custom JSR-223 provider.
+# This option has no effect, if enable_user_defined_functions is false.
+enable_scripted_user_defined_functions: false
+
+# The default Windows kernel timer and scheduling resolution is 15.6ms for power conservation.
+# Lowering this value on Windows can provide much tighter latency and better throughput, however
+# some virtualized environments may see a negative performance impact from changing this setting
+# below their system default. The sysinternals 'clockres' tool can confirm your system's default
+# setting.
+windows_timer_interval: 1
+
+
+# Enables encrypting data at-rest (on disk). Different key providers can be plugged in, but the default reads from
+# a JCE-style keystore. A single keystore can hold multiple keys, but the one referenced by
+# the "key_alias" is the only key that will be used for encrypt opertaions; previously used keys
+# can still (and should!) be in the keystore and will be used on decrypt operations
+# (to handle the case of key rotation).
+#
+# It is strongly recommended to download and install Java Cryptography Extension (JCE)
+# Unlimited Strength Jurisdiction Policy Files for your version of the JDK.
+# (current link: http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html)
+#
+# Currently, only the following file types are supported for transparent data encryption, although
+# more are coming in future cassandra releases: commitlog, hints
+transparent_data_encryption_options:
+    enabled: false
+    chunk_length_kb: 64
+    cipher: AES/CBC/PKCS5Padding
+    key_alias: testing:1
+    # CBC IV length for AES needs to be 16 bytes (which is also the default size)
+    # iv_length: 16
+    key_provider: 
+      - class_name: org.apache.cassandra.security.JKSKeyProvider
+        parameters: 
+          - keystore: conf/.keystore
+            keystore_password: cassandra
+            store_type: JCEKS
+            key_password: cassandra
+
+
+#####################
+# SAFETY THRESHOLDS #
+#####################
+
+# When executing a scan, within or across a partition, we need to keep the
+# tombstones seen in memory so we can return them to the coordinator, which
+# will use them to make sure other replicas also know about the deleted rows.
+# With workloads that generate a lot of tombstones, this can cause performance
+# problems and even exaust the server heap.
+# (http://www.datastax.com/dev/blog/cassandra-anti-patterns-queues-and-queue-like-datasets)
+# Adjust the thresholds here if you understand the dangers and want to
+# scan more tombstones anyway.  These thresholds may also be adjusted at runtime
+# using the StorageService mbean.
+tombstone_warn_threshold: 1000
+tombstone_failure_threshold: 100000
+
+# Log WARN on any multiple-partition batch size exceeding this value. 5kb per batch by default.
+# Caution should be taken on increasing the size of this threshold as it can lead to node instability.
+batch_size_warn_threshold_in_kb: 5
+
+# Fail any multiple-partition batch exceeding this value. 50kb (10x warn threshold) by default.
+batch_size_fail_threshold_in_kb: 50
+
+# Log WARN on any batches not of type LOGGED than span across more partitions than this limit
+unlogged_batch_across_partitions_warn_threshold: 10
+
+# Log a warning when compacting partitions larger than this value
+compaction_large_partition_warning_threshold_mb: 100
+
+# GC Pauses greater than gc_warn_threshold_in_ms will be logged at WARN level
+# Adjust the threshold based on your application throughput requirement
+# By default, Cassandra logs GC Pauses greater than 200 ms at INFO level
+gc_warn_threshold_in_ms: 1000
+
+# Maximum size of any value in SSTables. Safety measure to detect SSTable corruption
+# early. Any value size larger than this threshold will result into marking an SSTable
+# as corrupted. This should be positive and less than 2048.
+# max_value_size_in_mb: 256
+
+# Back-pressure settings #
+# If enabled, the coordinator will apply the back-pressure strategy specified below to each mutation
+# sent to replicas, with the aim of reducing pressure on overloaded replicas.
+back_pressure_enabled: false
+# The back-pressure strategy applied.
+# The default implementation, RateBasedBackPressure, takes three arguments:
+# high ratio, factor, and flow type, and uses the ratio between incoming mutation responses and outgoing mutation requests.
+# If below high ratio, outgoing mutations are rate limited according to the incoming rate decreased by the given factor;
+# if above high ratio, the rate limiting is increased by the given factor;
+# such factor is usually best configured between 1 and 10, use larger values for a faster recovery
+# at the expense of potentially more dropped mutations;
+# the rate limiting is applied according to the flow type: if FAST, it's rate limited at the speed of the fastest replica,
+# if SLOW at the speed of the slowest one.
+# New strategies can be added. Implementors need to implement org.apache.cassandra.net.BackpressureStrategy and
+# provide a public constructor accepting a Map<String, Object>.
+back_pressure_strategy:
+    - class_name: org.apache.cassandra.net.RateBasedBackPressure
+      parameters:
+        - high_ratio: 0.90
+          factor: 5
+          flow: FAST
+
+# Coalescing Strategies #
+# Coalescing multiples messages turns out to significantly boost message processing throughput (think doubling or more).
+# On bare metal, the floor for packet processing throughput is high enough that many applications won't notice, but in
+# virtualized environments, the point at which an application can be bound by network packet processing can be
+# surprisingly low compared to the throughput of task processing that is possible inside a VM. It's not that bare metal
+# doesn't benefit from coalescing messages, it's that the number of packets a bare metal network interface can process
+# is sufficient for many applications such that no load starvation is experienced even without coalescing.
+# There are other benefits to coalescing network messages that are harder to isolate with a simple metric like messages
+# per second. By coalescing multiple tasks together, a network thread can process multiple messages for the cost of one
+# trip to read from a socket, and all the task submission work can be done at the same time reducing context switching
+# and increasing cache friendliness of network message processing.
+# See CASSANDRA-8692 for details.
+
+# Strategy to use for coalescing messages in OutboundTcpConnection.
+# Can be fixed, movingaverage, timehorizon, disabled (default).
+# You can also specify a subclass of CoalescingStrategies.CoalescingStrategy by name.
+# otc_coalescing_strategy: DISABLED
+
+# How many microseconds to wait for coalescing. For fixed strategy this is the amount of time after the first
+# message is received before it will be sent with any accompanying messages. For moving average this is the
+# maximum amount of time that will be waited as well as the interval at which messages must arrive on average
+# for coalescing to be enabled.
+# otc_coalescing_window_us: 200
+
+# Do not try to coalesce messages if we already got that many messages. This should be more than 2 and less than 128.
+# otc_coalescing_enough_coalesced_messages: 8
+
+# How many milliseconds to wait between two expiration runs on the backlog (queue) of the OutboundTcpConnection.
+# Expiration is done if messages are piling up in the backlog. Droppable messages are expired to free the memory
+# taken by expired messages. The interval should be between 0 and 1000, and in most installations the default value
+# will be appropriate. A smaller value could potentially expire messages slightly sooner at the expense of more CPU
+# time and queue contention while iterating the backlog of messages.
+# An interval of 0 disables any wait time, which is the behavior of former Cassandra versions.
+#
+# otc_backlog_expiration_interval_ms: 200
+`

--- a/ci/nightly.sh
+++ b/ci/nightly.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+go get ./...
+go install
+
+curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-182.0.0-linux-x86_64.tar.gz
+tar -zxf google-cloud-sdk-182.0.0-linux-x86_64.tar.gz
+./google-cloud-sdk/install.sh
+source google-cloud-sdk/path.bash.inc
+
+echo $GOOGLE_CREDENTIALS > creds.json
+
+gcloud auth activate-service-account --key-file=creds.json
+
+# It might already exist.
+roachprod -u teamcity create teamcity-nightly || roachprod sync
+
+eval $(ssh-agent)
+ssh-add ~/.ssh/google_compute_engine
+
+curl -L https://edge-binaries.cockroachdb.com/cockroach/cockroach.linux-gnu-amd64.LATEST -o cockroach
+chmod +x cockroach
+curl -L https://edge-binaries.cockroachdb.com/loadgen/kv.LATEST -o kv
+chmod +x kv
+
+roachprod put teamcity-nightly ./cockroach ./cockroach
+roachprod put teamcity-nightly ./kv ./kv
+
+cd artifacts
+roachprod test teamcity-nightly nightly
+roachprod upload $(ls)
+
+roachprod -u teamcity destroy teamcity-nightly

--- a/ci/teamcity-nightly.sh
+++ b/ci/teamcity-nightly.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+echo "${TEST_CLUSTER_SSH_KEY}" > id_test_cluster.rsa
+mkdir -p artifacts
+docker run \
+    --workdir=/go/src/github.com/cockroachdb/roachprod \
+    --volume="${GOPATH%%:*}/src":/go/src \
+    --volume="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)":/go/src/github.com/cockroachdb/roachprod \
+    --env="AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" \
+    --env="AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" \
+    --env="GOOGLE_CREDENTIALS=${GOOGLE_CREDENTIALS}" \
+    --rm \
+    cockroachdb/builder:20171004-085709 pwd && ls && ci/nightly.sh

--- a/cluster_synced.go
+++ b/cluster_synced.go
@@ -1,0 +1,562 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"math"
+	"os"
+	"os/signal"
+	"sort"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+type clusterImpl interface {
+	start(c *syncedCluster)
+	nodeURL(c *syncedCluster, host string, port int) string
+	nodePort(c *syncedCluster, index int) int
+}
+
+// A syncedCluster is created from the information in the synced hosts file.
+//
+// TODO(benesch): unify with CloudCluster.
+type syncedCluster struct {
+	// name, vms, users, localities are populated at init time.
+	name       string
+	vms        []string
+	users      []string
+	localities []string
+	// all other fields are populated in newCluster.
+	nodes   []int
+	loadGen int
+	secure  bool
+	env     string
+	args    []string
+	impl    clusterImpl
+}
+
+func (c *syncedCluster) host(index int) string {
+	return c.vms[index-1]
+}
+
+func (c *syncedCluster) user(index int) string {
+	return c.users[index-1]
+}
+
+func (c *syncedCluster) locality(index int) string {
+	return c.localities[index-1]
+}
+
+func (c *syncedCluster) isLocal() bool {
+	return c.name == local
+}
+
+func (c *syncedCluster) serverNodes() []int {
+	if c.loadGen == -1 {
+		return c.nodes
+	}
+	newNodes := make([]int, 0, len(c.nodes))
+	for _, i := range c.nodes {
+		if i != c.loadGen {
+			newNodes = append(newNodes, i)
+		}
+	}
+	return newNodes
+}
+
+// getInternalIP returns the internal IP address of the specified node.
+func (c *syncedCluster) getInternalIP(index int) (string, error) {
+	if c.isLocal() {
+		return c.host(index), nil
+	}
+
+	session, err := newSSHSession(c.user(index), c.host(index))
+	if err != nil {
+		return "", nil
+	}
+	defer session.Close()
+
+	cmd := `hostname --all-ip-addresses`
+	out, err := session.CombinedOutput(cmd)
+	if err != nil {
+		return "", nil
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func (c *syncedCluster) start() {
+	c.impl.start(c)
+}
+
+func (c *syncedCluster) stop() {
+	display := fmt.Sprintf("%s: stopping", c.name)
+	c.parallel(display, len(c.nodes), 0, func(i int) ([]byte, error) {
+		session, err := newSSHSession(c.user(c.nodes[i]), c.host(c.nodes[i]))
+		if err != nil {
+			return nil, err
+		}
+		defer session.Close()
+
+		cmd := `pkill -9 "cockroach|java|mongo|kv|ycsb" || true ;
+`
+		cmd += fmt.Sprintf("kill -9 $(lsof -t -i :%d -i :%d) 2>/dev/null || true ;\n",
+			cockroach{}.nodePort(c, c.nodes[i]),
+			cassandra{}.nodePort(c, c.nodes[i]))
+		return session.CombinedOutput(cmd)
+	})
+}
+
+func (c *syncedCluster) wipe() {
+	display := fmt.Sprintf("%s: wiping", c.name)
+	c.parallel(display, len(c.nodes), 0, func(i int) ([]byte, error) {
+		session, err := newSSHSession(c.user(c.nodes[i]), c.host(c.nodes[i]))
+		if err != nil {
+			return nil, err
+		}
+		defer session.Close()
+
+		cmd := `pkill -9 "cockroach|java|mongo|kv|ycsb" || true ;
+`
+		cmd += fmt.Sprintf("kill -9 $(lsof -t -i :%d -i :%d) 2>/dev/null || true ;\n",
+			cockroach{}.nodePort(c, c.nodes[i]),
+			cassandra{}.nodePort(c, c.nodes[i]))
+		if c.isLocal() {
+			cmd += `rm -fr ${HOME}/local ;`
+		} else {
+			cmd += `find /mnt/data* -maxdepth 1 -type f -exec rm -f {} \; ;
+rm -fr /mnt/data*/{auxiliary,local,tmp,cassandra,cockroach,cockroach-temp*,mongo-data} \; ;
+`
+		}
+		return session.CombinedOutput(cmd)
+	})
+}
+
+func (c *syncedCluster) status() {
+	display := fmt.Sprintf("%s: status", c.name)
+	results := make([]string, len(c.nodes))
+	c.parallel(display, len(c.nodes), 0, func(i int) ([]byte, error) {
+		session, err := newSSHSession(c.user(c.nodes[i]), c.host(c.nodes[i]))
+		if err != nil {
+			results[i] = err.Error()
+			return nil, nil
+		}
+		defer session.Close()
+
+		cmd := fmt.Sprintf("out=$(lsof -i :%d -i :%d -sTCP:LISTEN",
+			cockroach{}.nodePort(c, c.nodes[i]),
+			cassandra{}.nodePort(c, c.nodes[i]))
+		cmd += ` | awk '!/COMMAND/ {print $1, $2}' | sort | uniq);
+vers=$(` + binary + ` version 2>/dev/null | awk '/Build Tag:/ {print $NF}')
+if [ -n "${out}" -a -n "${vers}" ]; then
+  echo ${out} | sed "s/cockroach/cockroach-${vers}/g"
+else
+  echo ${out}
+fi
+`
+		out, err := session.CombinedOutput(cmd)
+		var msg string
+		if err != nil {
+			msg = err.Error()
+		} else {
+			msg = strings.TrimSpace(string(out))
+			if msg == "" {
+				msg = "not running"
+			}
+		}
+		results[i] = msg
+		return nil, nil
+	})
+
+	for i, r := range results {
+		fmt.Printf("  %2d: %s\n", c.nodes[i], r)
+	}
+}
+
+func (c *syncedCluster) run(w io.Writer, nodes []int, title, cmd string) error {
+	display := fmt.Sprintf("%s: %s", c.name, title)
+	errors := make([]error, len(nodes))
+	results := make([]string, len(nodes))
+	c.parallel(display, len(nodes), 0, func(i int) ([]byte, error) {
+		session, err := newSSHSession(c.user(nodes[i]), c.host(nodes[i]))
+		if err != nil {
+			errors[i] = err
+			results[i] = err.Error()
+			return nil, nil
+		}
+		defer session.Close()
+
+		out, err := session.CombinedOutput(cmd)
+		msg := strings.TrimSpace(string(out))
+		if err != nil {
+			errors[i] = err
+			msg += fmt.Sprintf("\n%v", err)
+		}
+		results[i] = msg
+		return nil, nil
+	})
+
+	for i, r := range results {
+		fmt.Fprintf(w, "  %2d: %s\n", nodes[i], r)
+	}
+
+	for _, err := range errors {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *syncedCluster) cockroachVersions() map[string]int {
+	sha := make(map[string]int)
+	var mu sync.Mutex
+
+	display := fmt.Sprintf("%s: cockroach version", c.name)
+	nodes := c.serverNodes()
+	c.parallel(display, len(nodes), 0, func(i int) ([]byte, error) {
+		session, err := newSSHSession(c.user(c.nodes[i]), c.host(nodes[i]))
+		if err != nil {
+			return nil, err
+		}
+		defer session.Close()
+
+		cmd := binary + " version | awk '/Build Tag:/ {print $NF}'"
+		out, err := session.CombinedOutput(cmd)
+		var s string
+		if err != nil {
+			s = err.Error()
+		} else {
+			s = strings.TrimSpace(string(out))
+		}
+		mu.Lock()
+		sha[s]++
+		mu.Unlock()
+		return nil, err
+	})
+
+	return sha
+}
+
+func (c *syncedCluster) runLoad(cmd string, stdout, stderr io.Writer) error {
+	if c.loadGen == 0 {
+		log.Fatalf("%s: no load generator node specified", c.name)
+	}
+
+	display := fmt.Sprintf("%s: retrieving IP addresses", c.name)
+	nodes := c.serverNodes()
+	ips := make([]string, len(nodes))
+	c.parallel(display, len(nodes), 0, func(i int) ([]byte, error) {
+		var err error
+		ips[i], err = c.getInternalIP(nodes[i])
+		return nil, err
+	})
+
+	session, err := newSSHSession(c.user(c.loadGen), c.host(c.loadGen))
+	if err != nil {
+		return err
+	}
+	defer session.Close()
+
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
+	defer func() {
+		signal.Stop(ch)
+		close(ch)
+	}()
+	go func() {
+		_, ok := <-ch
+		if ok {
+			c.stopLoad()
+		}
+	}()
+
+	session.Stdout = stdout
+	session.Stderr = stderr
+	fmt.Fprintln(stdout, cmd)
+
+	var urls []string
+	for i, ip := range ips {
+		urls = append(urls, c.impl.nodeURL(c, ip, c.impl.nodePort(c, nodes[i])))
+	}
+	return session.Run("ulimit -n 16384; " + cmd + " " + strings.Join(urls, " "))
+}
+
+const progressDone = "=======================================>"
+const progressTodo = "----------------------------------------"
+
+func formatProgress(p float64) string {
+	i := int(math.Ceil(float64(len(progressDone)) * (1 - p)))
+	return fmt.Sprintf("[%s%s] %.0f%%", progressDone[i:], progressTodo[:i], 100*p)
+}
+
+func (c *syncedCluster) put(src, dest string) {
+	// TODO(peter): Only put 10 nodes at a time. When a node completes, output a
+	// line indicating that.
+	fmt.Printf("%s: putting %s %s\n", c.name, src, dest)
+
+	type result struct {
+		index int
+		err   error
+	}
+
+	var writer uiWriter
+	results := make(chan result, len(c.nodes))
+	lines := make([]string, len(c.nodes))
+	var linesMu sync.Mutex
+
+	var wg sync.WaitGroup
+	for i := range c.nodes {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			session, err := newSSHSession(c.user(c.nodes[i]), c.host(c.nodes[i]))
+			if err == nil {
+				defer session.Close()
+				err = scpPut(src, dest, func(p float64) {
+					linesMu.Lock()
+					defer linesMu.Unlock()
+					lines[i] = formatProgress(p)
+				}, session)
+			}
+			results <- result{i, err}
+		}(i)
+	}
+
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	haveErr := false
+
+	var spinner = []string{"|", "/", "-", "\\"}
+	spinnerIdx := 0
+
+	for done := false; !done; {
+		select {
+		case <-ticker.C:
+		case r, ok := <-results:
+			done = !ok
+			if ok {
+				linesMu.Lock()
+				if r.err != nil {
+					haveErr = true
+					lines[r.index] = r.err.Error()
+				} else {
+					lines[r.index] = "done"
+				}
+				linesMu.Unlock()
+			}
+		}
+		linesMu.Lock()
+		for i := range lines {
+			fmt.Fprintf(&writer, "  %2d: ", c.nodes[i])
+			if lines[i] != "" {
+				fmt.Fprintf(&writer, "%s", lines[i])
+			} else {
+				fmt.Fprintf(&writer, "%s", spinner[spinnerIdx%len(spinner)])
+			}
+			fmt.Fprintf(&writer, "\n")
+		}
+		linesMu.Unlock()
+		writer.Flush(os.Stdout)
+		spinnerIdx++
+	}
+
+	if haveErr {
+		log.Fatal("failed")
+	}
+}
+
+func (c *syncedCluster) get(src, dest string) {
+	// TODO(peter): Only get 10 nodes at a time. When a node completes, output a
+	// line indicating that.
+	fmt.Printf("%s: getting %s %s\n", c.name, src, dest)
+
+	type result struct {
+		index int
+		err   error
+	}
+
+	var writer uiWriter
+	results := make(chan result, len(c.nodes))
+	lines := make([]string, len(c.nodes))
+	var linesMu sync.Mutex
+
+	var wg sync.WaitGroup
+	for i := range c.nodes {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			session, err := newSSHSession(c.user(c.nodes[i]), c.host(c.nodes[i]))
+			if err == nil {
+				defer session.Close()
+				dest := dest
+				if len(c.nodes) > 1 {
+					dest = fmt.Sprintf("%d.%s", c.nodes[i], dest)
+				}
+				err = scpGet(src, dest, func(p float64) {
+					linesMu.Lock()
+					defer linesMu.Unlock()
+					lines[i] = formatProgress(p)
+				}, session)
+			}
+			results <- result{i, err}
+		}(i)
+	}
+
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	haveErr := false
+
+	var spinner = []string{"|", "/", "-", "\\"}
+	spinnerIdx := 0
+
+	for done := false; !done; {
+		select {
+		case <-ticker.C:
+		case r, ok := <-results:
+			done = !ok
+			if ok {
+				linesMu.Lock()
+				if r.err != nil {
+					haveErr = true
+					lines[r.index] = r.err.Error()
+				} else {
+					lines[r.index] = "done"
+				}
+				linesMu.Unlock()
+			}
+		}
+		linesMu.Lock()
+		for i := range lines {
+			fmt.Fprintf(&writer, "  %2d: ", c.nodes[i])
+			if lines[i] != "" {
+				fmt.Fprintf(&writer, "%s", lines[i])
+			} else {
+				fmt.Fprintf(&writer, "%s", spinner[spinnerIdx%len(spinner)])
+			}
+			fmt.Fprintf(&writer, "\n")
+		}
+		linesMu.Unlock()
+		writer.Flush(os.Stdout)
+		spinnerIdx++
+	}
+
+	if haveErr {
+		log.Fatal("failed")
+	}
+}
+
+func (c *syncedCluster) stopLoad() {
+	if c.loadGen == 0 {
+		log.Fatalf("no load generator node specified for cluster: %s", c.name)
+	}
+
+	display := fmt.Sprintf("%s: stopping load", c.name)
+	c.parallel(display, 1, 0, func(i int) ([]byte, error) {
+		session, err := newSSHSession(c.user(c.loadGen), c.host(c.loadGen))
+		if err != nil {
+			return nil, err
+		}
+		defer session.Close()
+
+		cmd := fmt.Sprintf("kill -9 $(lsof -t -i :%d -i :%d) 2>/dev/null || true",
+			cockroach{}.nodePort(c, c.nodes[i]),
+			cassandra{}.nodePort(c, c.nodes[i]))
+		return session.CombinedOutput(cmd)
+	})
+}
+
+func (c *syncedCluster) parallel(display string, count, concurrency int, fn func(i int) ([]byte, error)) {
+	if concurrency == 0 || concurrency > count {
+		concurrency = count
+	}
+
+	type result struct {
+		index int
+		out   []byte
+		err   error
+	}
+
+	results := make(chan result, count)
+	var wg sync.WaitGroup
+	wg.Add(count)
+
+	var index int
+	startNext := func() {
+		go func(i int) {
+			defer wg.Done()
+			out, err := fn(i)
+			results <- result{i, out, err}
+		}(index)
+		index++
+	}
+
+	for index < concurrency {
+		startNext()
+	}
+
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	var writer uiWriter
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	complete := make([]bool, count)
+	var failed []result
+
+	var spinner = []string{"|", "/", "-", "\\"}
+	spinnerIdx := 0
+
+	for done := false; !done; {
+		select {
+		case <-ticker.C:
+		case r, ok := <-results:
+			if r.err != nil {
+				failed = append(failed, r)
+			}
+			done = !ok
+			if ok {
+				complete[r.index] = true
+			}
+			if index < count {
+				startNext()
+			}
+		}
+		fmt.Fprint(&writer, display)
+		var n int
+		for i := range complete {
+			if complete[i] {
+				n++
+			}
+		}
+		fmt.Fprintf(&writer, " %d/%d", n, len(complete))
+		if !done {
+			fmt.Fprintf(&writer, " %s", spinner[spinnerIdx%len(spinner)])
+		}
+		fmt.Fprintf(&writer, "\n")
+		writer.Flush(os.Stdout)
+		spinnerIdx++
+	}
+
+	if len(failed) > 0 {
+		sort.Slice(failed, func(i, j int) bool { return failed[i].index < failed[j].index })
+		for _, f := range failed {
+			fmt.Fprintf(os.Stderr, "%d: %s: %s\n", f.index, f.err, f.out)
+		}
+		log.Fatal("command failed")
+	}
+}

--- a/cockroach.go
+++ b/cockroach.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+type cockroach struct{}
+
+func (r cockroach) start(c *syncedCluster) {
+	display := fmt.Sprintf("%s: starting", c.name)
+	host1 := c.host(1)
+	nodes := c.serverNodes()
+	c.parallel(display, len(nodes), 0, func(i int) ([]byte, error) {
+		host := c.host(nodes[i])
+		user := c.user(nodes[i])
+		session, err := newSSHSession(user, host)
+		if err != nil {
+			return nil, err
+		}
+		defer session.Close()
+
+		port := r.nodePort(c, nodes[i])
+
+		var args []string
+		if c.secure {
+			args = append(args, "--certs-dir=certs")
+		} else {
+			args = append(args, "--insecure")
+		}
+		dir := "/mnt/data1/cockroach"
+		if c.isLocal() {
+			dir = fmt.Sprintf("${HOME}/local/cockroach%d", nodes[i])
+		}
+		args = append(args, "--store=path="+dir)
+		args = append(args, "--logtostderr")
+		args = append(args, "--log-dir=")
+		args = append(args, "--background")
+		cache := 25
+		if c.isLocal() {
+			cache /= len(nodes)
+			if cache == 0 {
+				cache = 1
+			}
+		}
+		args = append(args, fmt.Sprintf("--cache=%d%%", cache))
+		args = append(args, fmt.Sprintf("--max-sql-memory=%d%%", cache))
+		args = append(args, fmt.Sprintf("--port=%d", port))
+		args = append(args, fmt.Sprintf("--http-port=%d", port+1))
+		if locality := c.locality(nodes[i]); locality != "" {
+			args = append(args, "--locality="+locality)
+		}
+		if nodes[i] != 1 {
+			args = append(args, fmt.Sprintf("--join=%s:%d", host1, r.nodePort(c, 1)))
+		}
+		args = append(args, c.args...)
+		cmd := "mkdir -p " + dir + "/logs; " +
+			c.env + " " + binary + " start " + strings.Join(args, " ") +
+			" > " + dir + "/logs/cockroach.stdout 2> " + dir + "/logs/cockroach.stderr"
+		return session.CombinedOutput(cmd)
+	})
+
+	// Check to see if node 1 was started indicating the cluster was
+	// bootstrapped.
+	var bootstrapped bool
+	for _, i := range nodes {
+		if i == 1 {
+			bootstrapped = true
+			break
+		}
+	}
+
+	if bootstrapped {
+		var msg string
+		display = fmt.Sprintf("%s: initializing cluster settings", c.name)
+		c.parallel(display, 1, 0, func(i int) ([]byte, error) {
+			session, err := newSSHSession(c.user(1), c.host(1))
+			if err != nil {
+				return nil, err
+			}
+			defer session.Close()
+
+			cmd := binary + ` sql --url ` + r.nodeURL(c, "localhost", r.nodePort(c, 1)) + ` -e "
+set cluster setting kv.allocator.stat_based_rebalancing.enabled = false;
+set cluster setting server.remote_debugging.mode = 'any';
+"`
+			out, err := session.CombinedOutput(cmd)
+			if err != nil {
+				msg = err.Error()
+			} else {
+				msg = strings.TrimSpace(string(out))
+			}
+			return nil, nil
+		})
+
+		fmt.Println(msg)
+	}
+}
+
+func (cockroach) nodeURL(c *syncedCluster, host string, port int) string {
+	url := fmt.Sprintf("'postgres://root@%s:%d", host, port)
+	if c.secure {
+		url += "?sslcert=certs%2Fnode.crt&sslkey=certs%2Fnode.key&" +
+			"sslrootcert=certs%2Fca.crt&sslmode=verify-full"
+	} else {
+		url += "?sslmode=disable"
+	}
+	url += "'"
+	return url
+}
+
+func (cockroach) nodePort(c *syncedCluster, index int) int {
+	const basePort = 26257
+	port := basePort
+	if c.isLocal() {
+		port += (index - 1) * 2
+	}
+	return port
+}

--- a/dump.go
+++ b/dump.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+)
+
+func dump(dirs []string) error {
+	switch n := len(dirs); n {
+	case 0:
+		return fmt.Errorf("no test directory specified")
+	case 1, 2:
+		d1, err := loadTestData(dirs[0])
+		if err != nil {
+			return err
+		}
+		if n == 1 {
+			return dump1(d1)
+		}
+		d2, err := loadTestData(dirs[1])
+		if err != nil {
+			return err
+		}
+		return dump2(d1, d2)
+	default:
+		return fmt.Errorf("too many test directories: %s", dirs)
+	}
+}
+
+func dump1(d *testData) error {
+	fmt.Println(d.Metadata.Test)
+	fmt.Println("_____N_____ops/sec__avg(ms)__p50(ms)__p95(ms)__p99(ms)")
+	for _, r := range d.Runs {
+		fmt.Printf("%6d %11.1f %8.1f %8.1f %8.1f %8.1f\n", r.Concurrency,
+			r.OpsSec, r.AvgLat, r.P50Lat, r.P95Lat, r.P99Lat)
+	}
+	return nil
+}
+
+func dump2(d1, d2 *testData) error {
+	d1, d2 = alignTestData(d1, d2)
+	fmt.Println(d1.Metadata.Test)
+	fmt.Println("_____N__ops/sec(1)__ops/sec(2)_____delta")
+	for i := range d1.Runs {
+		r1 := d1.Runs[i]
+		r2 := d2.Runs[i]
+		fmt.Printf("%6d %11.1f %11.1f %8.2f%%\n",
+			r1.Concurrency, r1.OpsSec, r2.OpsSec, 100*(r2.OpsSec-r1.OpsSec)/r1.OpsSec)
+	}
+	return nil
+}

--- a/hosts.go
+++ b/hosts.go
@@ -8,6 +8,7 @@ import (
 	"os/user"
 	"path"
 	"path/filepath"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/pkg/errors"
@@ -15,6 +16,7 @@ import (
 
 const (
 	defaultHostDir   = "${HOME}/.roachprod/hosts"
+	local            = "local"
 	sshKeyPathPrefix = "${HOME}/.ssh/roachprod"
 )
 
@@ -76,6 +78,78 @@ func gcHostsFiles(cloud *Cloud) error {
 		if err = os.Remove(filename); err != nil {
 			log.Printf("failed to remove file %s", filename)
 		}
+	}
+	return nil
+}
+
+func newInvalidHostsLineErr(line string) error {
+	return fmt.Errorf("invalid hosts line, expected <username>@<host> [locality], got %q", line)
+}
+
+func loadClusters() error {
+	hd := os.ExpandEnv(defaultHostDir)
+	files, err := ioutil.ReadDir(hd)
+	if err != nil {
+		return err
+	}
+
+	for _, file := range files {
+		if !file.Mode().IsRegular() {
+			continue
+		}
+
+		filename := filepath.Join(hd, file.Name())
+		contents, err := ioutil.ReadFile(filename)
+		if err != nil {
+			return errors.Wrapf(err, "could not read %s", filename)
+		}
+		lines := strings.Split(string(contents), "\n")
+
+		c := &syncedCluster{
+			name: file.Name(),
+		}
+
+		for _, l := range lines {
+			fields := strings.Fields(l)
+			if len(fields) == 0 {
+				continue
+			} else if len(fields[0]) > 0 && fields[0][0] == '#' {
+				// Comment line.
+				continue
+			} else if len(fields) > 2 {
+				return newInvalidHostsLineErr(l)
+			}
+
+			parts := strings.Split(fields[0], "@")
+			var n, u string
+			if len(parts) == 1 {
+				user, err := user.Current()
+				if err != nil {
+					return errors.Wrapf(err, "failed to lookup current user")
+				}
+				u = user.Username
+				n = parts[0]
+			} else if len(parts) == 2 {
+				u = parts[0]
+				n = parts[1]
+			} else {
+				return newInvalidHostsLineErr(l)
+			}
+
+			var l string
+			if len(fields) == 2 {
+				l = fields[1]
+			}
+
+			c.vms = append(c.vms, n)
+			c.users = append(c.users, u)
+			c.localities = append(c.localities, l)
+		}
+		clusters[file.Name()] = c
+	}
+
+	clusters[local] = &syncedCluster{
+		name: local,
 	}
 	return nil
 }

--- a/install.go
+++ b/install.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+)
+
+func install(c *syncedCluster, args []string) error {
+	do := func(title, cmd string) error {
+		var buf bytes.Buffer
+		err := c.run(&buf, c.nodes, "installing "+title, cmd)
+		if err != nil {
+			fmt.Print(buf.String())
+		}
+		return err
+	}
+
+	for _, arg := range args {
+		switch arg {
+		case "cassandra":
+			cmd := `
+echo "deb http://www.apache.org/dist/cassandra/debian 311x main" | \
+  sudo tee -a /etc/apt/sources.list.d/cassandra.sources.list;
+curl https://www.apache.org/dist/cassandra/KEYS | sudo apt-key add -;
+sudo apt-get update;
+sudo apt-get install -y cassandra;
+sudo service cassandra stop;
+`
+			if err := do("cassandra", cmd); err != nil {
+				return err
+			}
+
+		case "mongodb":
+			return fmt.Errorf("TODO(peter): unimplemented: mongodb")
+
+		case "postgres":
+			return fmt.Errorf("TODO(peter): unimplemented: postgres")
+
+		case "tools":
+			cmd := `
+sudo apt-get update;
+sudo apt-get install -y \
+  fio \
+  iftop \
+  iotop \
+  sysstat \
+  linux-tools-common \
+  linux-tools-4.10.0-35-generic \
+  linux-cloud-tools-4.10.0-35-generic;
+`
+			if err := do("tools", cmd); err != nil {
+				return err
+			}
+
+		default:
+			return fmt.Errorf("unknown tool %q", arg)
+		}
+	}
+	return nil
+}

--- a/json.go
+++ b/json.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+)
+
+func prettyJSON(v interface{}) string {
+	data, err := json.MarshalIndent(v, "", "\t")
+	if err != nil {
+		log.Fatal(err)
+	}
+	return string(data)
+}
+
+func saveJSON(path string, v interface{}) {
+	data, err := json.MarshalIndent(v, "", "\t")
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := ioutil.WriteFile(path, data, 0666); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func loadJSON(path string, v interface{}) error {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, v)
+}

--- a/main.go
+++ b/main.go
@@ -3,18 +3,24 @@ package main
 import (
 	"fmt"
 	"os"
+	"os/exec"
+	"os/user"
+	"path"
+	"path/filepath"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
 var rootCmd = &cobra.Command{
 	Use:   "roachprod [command] (flags)",
 	Short: "roachprod tool for manipulating test clusters",
-	Long: `
-roachprod is a tool for manipulating test clusters, allowing easy creating,
-destroying and wiping of clusters along with running load generators.
+	Long: `roachprod is a tool for manipulating test clusters, allowing easy starting,
+stopping and wiping of clusters along with running load generators.
 `,
 }
 
@@ -24,8 +30,191 @@ var (
 	destroyAfter   time.Duration
 	trackingFile   string
 	extendLifetime time.Duration
+	listDetails    bool
 	zones          []string
+	clusterType    = "cockroach"
+	secure         = false
+	nodeEnv        = "COCKROACH_ENABLE_RPC_COMPRESSION=false"
+	nodeArgs       []string
+	binary         = "./cockroach"
+	clusters       = map[string]*syncedCluster{}
 )
+
+func listNodes(s string, total int) ([]int, error) {
+	if s == "all" {
+		r := make([]int, total)
+		for i := range r {
+			r[i] = i + 1
+		}
+		return r, nil
+	}
+
+	m := map[int]bool{}
+	for _, p := range strings.Split(s, ",") {
+		parts := strings.Split(p, "-")
+		switch len(parts) {
+		case 1:
+			i, err := strconv.Atoi(parts[0])
+			if err != nil {
+				return nil, err
+			}
+			m[i] = true
+		case 2:
+			from, err := strconv.Atoi(parts[0])
+			if err != nil {
+				return nil, err
+			}
+			to, err := strconv.Atoi(parts[1])
+			if err != nil {
+				return nil, err
+			}
+			for i := from; i <= to; i++ {
+				m[i] = true
+			}
+		default:
+			return nil, fmt.Errorf("unable to parse nodes specification: %s", p)
+		}
+	}
+
+	r := make([]int, 0, len(m))
+	for i := range m {
+		r = append(r, i)
+	}
+	sort.Ints(r)
+	return r, nil
+}
+
+func findLocalBinary() error {
+	// For "local" clusters we have to find the binary to run and translate it to
+	// an absolute path. First, look for the binary in PATH.
+	path, err := exec.LookPath(binary)
+	if err != nil {
+		if strings.HasPrefix(binary, "/") {
+			return err
+		}
+		// We're unable to find the binary in PATH and "binary" is a relative path:
+		// look in the cockroach repo.
+		gopath := os.Getenv("GOPATH")
+		if gopath == "" {
+			return err
+		}
+		path = gopath + "/src/github.com/cockroachdb/cockroach/" + binary
+		var err2 error
+		path, err2 = exec.LookPath(path)
+		if err2 != nil {
+			return err
+		}
+	}
+	path, err = filepath.Abs(path)
+	if err != nil {
+		return err
+	}
+	binary = path
+	return nil
+}
+
+func sortedClusters() []string {
+	var r []string
+	for n := range clusters {
+		r = append(r, n)
+	}
+	sort.Strings(r)
+	return r
+}
+
+func newCluster(name string, reserveLoadGen bool) (*syncedCluster, error) {
+	nodeNames := "all"
+	{
+		parts := strings.Split(name, ":")
+		switch len(parts) {
+		case 2:
+			nodeNames = parts[1]
+			fallthrough
+		case 1:
+			name = parts[0]
+		case 0:
+			return nil, fmt.Errorf("no cluster specified")
+		default:
+			return nil, fmt.Errorf("invalid cluster name: %s", name)
+		}
+	}
+
+	c, ok := clusters[name]
+	if !ok {
+		return nil, fmt.Errorf(`unknown cluster: %s
+
+Available clusters:
+  %s
+
+Hint: use "roachprod sync" to update the list of available clusters.
+`,
+			name, strings.Join(sortedClusters(), "\n  "))
+	}
+
+	switch clusterType {
+	case "cockroach":
+		c.impl = cockroach{}
+	case "cassandra":
+		c.impl = cassandra{}
+	default:
+		return nil, fmt.Errorf("unknown cluster type: %s", clusterType)
+	}
+
+	total := len(c.vms)
+	if c.isLocal() {
+		// If ${HOME}/local exists default to the number of nodes in the cluster.
+		if entries, err := filepath.Glob(os.ExpandEnv("${HOME}/local/*")); err == nil {
+			total = len(entries)
+		}
+		if total == 0 {
+			total = 1
+		}
+	}
+
+	nodes, err := listNodes(nodeNames, total)
+	if err != nil {
+		return nil, err
+	}
+
+	c.nodes = nodes
+	if reserveLoadGen {
+		// TODO(marc): make loadgen node configurable. For now, we always use the
+		// last ID (1-indexed).
+		c.loadGen = len(c.vms)
+	} else {
+		c.loadGen = -1
+	}
+	c.secure = secure
+	c.env = nodeEnv
+	c.args = nodeArgs
+
+	if c.isLocal() {
+		var max int
+		for _, i := range c.nodes {
+			if max < i {
+				max = i
+			}
+		}
+
+		user, err := user.Current()
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to lookup current user")
+		}
+
+		c.vms = make([]string, max+1)
+		c.users = make([]string, max+1)
+		c.localities = make([]string, max+1)
+		for i := range c.vms {
+			c.vms[i] = "localhost"
+			c.users[i] = user.Username
+		}
+
+		if err := findLocalBinary(); err != nil {
+			return nil, err
+		}
+	}
+	return c, nil
+}
 
 func verifyClusterName(clusterName string) (string, error) {
 	if len(clusterName) == 0 {
@@ -149,35 +338,8 @@ var destroyCmd = &cobra.Command{
 }
 
 var listCmd = &cobra.Command{
-	Use:   "list",
+	Use:   "list [--details]",
 	Short: "retrieve the list of clusters",
-	Long:  ``,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		cloud, err := listCloud()
-		if err != nil {
-			return err
-		}
-
-		for _, c := range cloud.Clusters {
-			c.PrintDetails()
-		}
-		if len(cloud.InvalidName) > 0 {
-			fmt.Printf("Bad VM names: %s\n", strings.Join(cloud.InvalidName.Names(), " "))
-		}
-		if len(cloud.NoExpiration) > 0 {
-			fmt.Printf("No expiration: %s\n", strings.Join(cloud.NoExpiration.Names(), " "))
-		}
-		if len(cloud.BadNetwork) > 0 {
-			fmt.Printf("Bad network: %s\n", strings.Join(cloud.BadNetwork.Names(), " "))
-		}
-
-		return syncAll(cloud)
-	},
-}
-
-var statusCmd = &cobra.Command{
-	Use:   "status",
-	Short: "retrieve your prod status",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		account, err := findActiveAccount()
@@ -190,11 +352,28 @@ var statusCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+
 		for _, c := range cloud.Clusters {
-			fmt.Printf("%s\n", c)
+			if listDetails {
+				c.PrintDetails()
+			} else {
+				fmt.Printf("%s\n", c)
+			}
 		}
 
-		return nil
+		if listDetails {
+			if len(cloud.InvalidName) > 0 {
+				fmt.Printf("Bad VM names: %s\n", strings.Join(cloud.InvalidName.Names(), " "))
+			}
+			if len(cloud.NoExpiration) > 0 {
+				fmt.Printf("No expiration: %s\n", strings.Join(cloud.NoExpiration.Names(), " "))
+			}
+			if len(cloud.BadNetwork) > 0 {
+				fmt.Printf("Bad network: %s\n", strings.Join(cloud.BadNetwork.Names(), " "))
+			}
+		}
+
+		return syncAll(cloud)
 	},
 }
 
@@ -288,10 +467,241 @@ var extendCmd = &cobra.Command{
 	},
 }
 
+var startCmd = &cobra.Command{
+	Use:   "start <cluster>",
+	Short: "start a cluster",
+	Long:  `Start a cluster.`,
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c, err := newCluster(args[0], false /* reserveLoadGen */)
+		if err != nil {
+			return err
+		}
+		c.start()
+		return nil
+	},
+}
+
+var stopCmd = &cobra.Command{
+	Use:   "stop <cluster>",
+	Short: "stop a cluster",
+	Long:  `Stop a cluster.`,
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c, err := newCluster(args[0], false /* reserveLoadGen */)
+		if err != nil {
+			return err
+		}
+		c.stop()
+		return nil
+	},
+}
+
+var statusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "retrieve the status of a cluster",
+	Long:  `Retrieve the status of a cluster.`,
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c, err := newCluster(args[0], false /* reserveLoadGen */)
+		if err != nil {
+			return err
+		}
+		c.status()
+		return nil
+	},
+}
+
+var wipeCmd = &cobra.Command{
+	Use:   "wipe <cluster>",
+	Short: "wipe a cluster",
+	Long:  `Wipe a cluster.`,
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c, err := newCluster(args[0], false /* reserveLoadGen */)
+		if err != nil {
+			return err
+		}
+		c.wipe()
+		return nil
+	},
+}
+
+var runCmd = &cobra.Command{
+	Use:   "run <cluster> <command> [args]",
+	Short: "run a command on the nodes in a cluster",
+	Long:  `Run a command on the nodes in a cluster.`,
+	Args:  cobra.MinimumNArgs(2),
+	RunE: func(_ *cobra.Command, args []string) error {
+		c, err := newCluster(args[0], false /* reserveLoadGen */)
+		if err != nil {
+			return err
+		}
+
+		cmd := strings.TrimSpace(strings.Join(args[1:], " "))
+		title := cmd
+		if len(title) > 30 {
+			title = title[:27] + "..."
+		}
+
+		_ = c.run(os.Stdout, c.nodes, title, cmd)
+		return nil
+	},
+}
+
+var testCmd = &cobra.Command{
+	Use:   "test <cluster> <name>...",
+	Short: "run one or more tests on a cluster",
+	Long: `Run one or more tests on a cluster. The test <name> must be one of:
+
+	` + strings.Join(allTests(), "\n\t") + `
+
+Alternately, an interrupted test can be resumed by specifying the output
+directory of a previous test. For example:
+
+	roachperf test denim kv_0.cockroach-6151ae1
+
+will restart the kv_0 test on denim using the cockroach binary with the build
+tag 6151ae1.`,
+	Args: cobra.MinimumNArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		for _, arg := range args[1:] {
+			if err := runTest(arg, args[0]); err != nil {
+				return err
+			}
+		}
+		return nil
+	},
+}
+
+var installCmd = &cobra.Command{
+	Use:   "install <cluster> <software>",
+	Short: "install 3rd party software",
+	Long: `Install third party software. Currently available installation options are:
+
+  cassandra
+  mongodb
+  postgres
+  tools (fio, iftop, perf)`,
+	Args: cobra.MinimumNArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c, err := newCluster(args[0], false /* reserveLoadGen */)
+		if err != nil {
+			return err
+		}
+		return install(c, args[1:])
+	},
+}
+
+var putCmd = &cobra.Command{
+	Use:   "put <cluster> <src> [<dest>]",
+	Short: "copy a local file to the nodes in a cluster",
+	Long:  `Copy a local file to the nodes in a cluster.`,
+	Args:  cobra.RangeArgs(2, 3),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		src := args[1]
+		dest := path.Base(src)
+		if len(args) == 3 {
+			dest = args[2]
+		}
+		c, err := newCluster(args[0], false /* reserveLoadGen */)
+		if err != nil {
+			return err
+		}
+		c.put(src, dest)
+		return nil
+	},
+}
+
+var getCmd = &cobra.Command{
+	Use:   "get <cluster> <src> [<dest>]",
+	Short: "copy a remote file from the nodes in a cluster",
+	Long: `Copy a remote file from the nodes in a cluster. If the file is retrieved from
+multiple nodes the destination file name will be prefixed with the node number.`,
+	Args: cobra.RangeArgs(2, 3),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		src := args[1]
+		dest := path.Base(src)
+		if len(args) == 3 {
+			dest = args[2]
+		}
+		c, err := newCluster(args[0], false /* reserveLoadGen */)
+		if err != nil {
+			return err
+		}
+		c.get(src, dest)
+		return nil
+	},
+}
+
+var pgurlCmd = &cobra.Command{
+	Use:   "pgurl <cluster>",
+	Short: "generate pgurls for the nodes in a cluster",
+	Long:  `Generate pgurls for the nodes in a cluster.`,
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c, err := newCluster(args[0], false /* reserveLoadGen */)
+		if err != nil {
+			return err
+		}
+
+		display := fmt.Sprintf("%s: retrieving IP addresses", c.name)
+		nodes := c.serverNodes()
+		ips := make([]string, len(nodes))
+		c.parallel(display, len(nodes), 0, func(i int) ([]byte, error) {
+			var err error
+			ips[i], err = c.getInternalIP(nodes[i])
+			return nil, err
+		})
+
+		var urls []string
+		for i, ip := range ips {
+			urls = append(urls, c.impl.nodeURL(c, ip, c.impl.nodePort(c, c.nodes[i])))
+		}
+		fmt.Println(strings.Join(urls, " "))
+		return nil
+	},
+}
+
+var uploadCmd = &cobra.Command{
+	Use:   "upload <testdir> <backend>",
+	Short: "upload test data to a backend",
+	Long: `
+Upload the artifacts from a test. Currently supports s3 only as a backend.
+`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return upload(args)
+	},
+}
+
+var webCmd = &cobra.Command{
+	Use:   "web <testdir> [<testdir>]",
+	Short: "visualize and compare test output",
+	Long: `
+Visualize the output of a single test or compare the output of two tests.
+`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return web(args)
+	},
+}
+
+var dumpCmd = &cobra.Command{
+	Use:   "dump <testdir> [<testdir>]",
+	Short: "dump test output",
+	Long:  ``,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return dump(args)
+	},
+}
+
 func main() {
 	cobra.EnableCommandSorting = false
 
-	rootCmd.AddCommand(createCmd, destroyCmd, extendCmd, listCmd, monitorCmd, statusCmd, syncCmd)
+	rootCmd.AddCommand(createCmd, destroyCmd, extendCmd, listCmd, monitorCmd, statusCmd, syncCmd,
+		startCmd, stopCmd, runCmd, wipeCmd, testCmd, installCmd, putCmd, getCmd, pgurlCmd,
+		uploadCmd, webCmd, dumpCmd)
+	rootCmd.Flags().BoolVar(
+		&insecureIgnoreHostKey, "insecure-ignore-host-key", true, "don't check ssh host keys")
 
 	createCmd.Flags().DurationVarP(&createVMOpts.Lifetime, "lifetime", "l", 12*time.Hour, "Lifetime of the cluster")
 	createCmd.Flags().BoolVar(&createVMOpts.UseLocalSSD, "local-ssd", true, "Use local SSD")
@@ -306,6 +716,8 @@ func main() {
 	extendCmd.Flags().DurationVarP(&extendLifetime, "lifetime", "l", 12*time.Hour, "Lifetime of the cluster")
 	extendCmd.Flags().StringVarP(&username, "username", "u", "", "Username to run under, detect if blank")
 
+	listCmd.Flags().BoolVarP(&listDetails, "details", "d", false, "Show cluster details")
+
 	monitorCmd.Flags().StringVar(&monitorEmailOpts.From, "email-from", "", "Address of the sender")
 	monitorCmd.Flags().StringVar(&monitorEmailOpts.Host, "email-host", "", "SMTP host")
 	monitorCmd.Flags().IntVar(&monitorEmailOpts.Port, "email-port", 587, "SMTP port")
@@ -314,8 +726,57 @@ func main() {
 	monitorCmd.Flags().DurationVar(&destroyAfter, "destroy-after", 6*time.Hour, "Destroy when this much time past expiration")
 	monitorCmd.Flags().StringVar(&trackingFile, "tracking-file", "roachprod.tracking.txt", "Tracking file to avoid duplicate emails")
 
+	startCmd.Flags().StringVarP(
+		&binary, "binary", "b", "./cockroach", "the remote cockroach binary used to start a server")
+
+	testCmd.Flags().StringVarP(
+		&binary, "binary", "b", "./cockroach", "the remote cockroach binary used to start a server")
+	testCmd.Flags().DurationVarP(
+		&duration, "duration", "d", 5*time.Minute, "the duration to run each test")
+	testCmd.Flags().StringVarP(
+		&concurrency, "concurrency", "c", "1-64", "the concurrency to run each test")
+
+	for _, cmd := range []*cobra.Command{
+		getCmd, putCmd, runCmd, startCmd, statusCmd, stopCmd, testCmd, wipeCmd, pgurlCmd, installCmd,
+	} {
+		cmd.Flags().BoolVar(
+			&secure, "secure", false, "use a secure cluster")
+		cmd.Flags().StringSliceVarP(
+			&nodeArgs, "args", "a", nil, "node arguments")
+		cmd.Flags().StringVarP(
+			&nodeEnv, "env", "e", nodeEnv, "node environment variables")
+		cmd.Flags().StringVarP(
+			&clusterType, "type", "t", clusterType, `cluster type ("cockroach" or "cassandra")`)
+
+		if cmd.Long == "" {
+			cmd.Long = cmd.Short
+		}
+		cmd.Long += fmt.Sprintf(`
+
+By default the operation is performed on all nodes in <cluster>. A subset
+of nodes can be specified by appending :<nodes> to the cluster name. The
+syntax of <nodes> is a comma separated list of specific node IDs or range
+of IDs. For example:
+
+    roachperf %[1]s marc-test:1-3,8-9
+
+will perform %[1]s on:
+
+    marc-test-1
+    marc-test-2
+    marc-test-3
+    marc-test-8
+    marc-test-9
+`, cmd.Name())
+	}
+
+	if err := loadClusters(); err != nil {
+		// We don't want to exit as we may be looking at the help message.
+		fmt.Printf("problem loading clusters: %s", err)
+	}
+
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
+		// Cobra has already printed the error message.
 		os.Exit(1)
 	}
 }

--- a/monitor.go
+++ b/monitor.go
@@ -27,9 +27,9 @@ var monitorEmailOpts EmailOpts
 // Tracks all the clusters to notify a user about.
 type userNotification struct {
 	Username string
-	Good     []*Cluster
-	Warning  []*Cluster
-	Destroy  []*Cluster
+	Good     []*CloudCluster
+	Warning  []*CloudCluster
+	Destroy  []*CloudCluster
 	BadVMs   []string
 }
 

--- a/ssh.go
+++ b/ssh.go
@@ -1,0 +1,235 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"os"
+	"path"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
+	"golang.org/x/crypto/ssh/knownhosts"
+)
+
+var knownHosts ssh.HostKeyCallback
+var knownHostsOnce sync.Once
+var insecureIgnoreHostKey bool
+
+func getKnownHosts() ssh.HostKeyCallback {
+	knownHostsOnce.Do(func() {
+		var err error
+		if insecureIgnoreHostKey {
+			knownHosts = ssh.InsecureIgnoreHostKey()
+		} else {
+			knownHosts, err = knownhosts.New(filepath.Join(os.Getenv("HOME"), ".ssh", "known_hosts"))
+			if err != nil {
+				log.Fatal(err)
+			}
+		}
+	})
+	return knownHosts
+}
+
+func newSSHClient(user, host string) (*ssh.Client, net.Conn, error) {
+	const authSockEnv = "SSH_AUTH_SOCK"
+	agentSocket := os.Getenv(authSockEnv)
+	if agentSocket == "" {
+		return nil, nil, fmt.Errorf("%s empty", authSockEnv)
+	}
+	sock, err := net.Dial("unix", agentSocket)
+	if err != nil {
+		return nil, nil, err
+	}
+	agent := agent.NewClient(sock)
+	signers, err := agent.Signers()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	config := &ssh.ClientConfig{
+		User:            user,
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(signers...)},
+		HostKeyCallback: getKnownHosts(),
+	}
+	config.SetDefaults()
+
+	addr := fmt.Sprintf("%s:22", host)
+	conn, err := net.DialTimeout("tcp", addr, 30*time.Second)
+	if err != nil {
+		return nil, nil, err
+	}
+	c, chans, reqs, err := ssh.NewClientConn(conn, addr, config)
+	if err != nil {
+		return nil, nil, err
+	}
+	return ssh.NewClient(c, chans, reqs), conn, nil
+}
+
+type sshClient struct {
+	sync.Mutex
+	*ssh.Client
+}
+
+var clients = make(map[string]*sshClient)
+var clientsMu sync.Mutex
+
+func newSSHSession(user, host string) (*ssh.Session, error) {
+	clientsMu.Lock()
+	target := fmt.Sprintf("%s@%s", user, host)
+	client := clients[target]
+	if client == nil {
+		client = &sshClient{}
+		clients[target] = client
+	}
+	clientsMu.Unlock()
+
+	client.Lock()
+	defer client.Unlock()
+	if client.Client == nil {
+		var err error
+		client.Client, _, err = newSSHClient(user, host)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return client.NewSession()
+}
+
+func isSigKill(err error) bool {
+	switch t := err.(type) {
+	case *ssh.ExitError:
+		return t.Signal() == string(ssh.SIGKILL)
+	}
+	return false
+}
+
+type progressWriter struct {
+	writer   io.Writer
+	done     int64
+	total    int64
+	progress func(float64)
+}
+
+func (p *progressWriter) Write(b []byte) (int, error) {
+	n, err := p.writer.Write(b)
+	if err == nil {
+		p.done += int64(n)
+		p.progress(float64(p.done) / float64(p.total))
+	}
+	return n, err
+}
+
+func scpPut(src, dest string, progress func(float64), session *ssh.Session) error {
+	f, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	s, err := f.Stat()
+	if err != nil {
+		return err
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		w, err := session.StdinPipe()
+		if err != nil {
+			errCh <- err
+			return
+		}
+		defer w.Close()
+		fmt.Fprintf(w, "C%#o %d %s\n", s.Mode().Perm(), s.Size(), path.Base(src))
+		p := &progressWriter{w, 0, s.Size(), progress}
+		if _, err := io.Copy(p, f); err != nil {
+			errCh <- err
+			return
+		}
+		fmt.Fprint(w, "\x00")
+		close(errCh)
+	}()
+
+	err = session.Run(fmt.Sprintf("rm -f %s ; scp -t %s", dest, dest))
+	select {
+	case err := <-errCh:
+		return err
+	default:
+		return err
+	}
+}
+
+// TODO(peter): Support retrieving a directory.
+func scpGet(src, dest string, progress func(float64), session *ssh.Session) error {
+	errCh := make(chan error, 1)
+	go func() {
+		rp, err := session.StdoutPipe()
+		if err != nil {
+			errCh <- err
+			return
+		}
+		wp, err := session.StdinPipe()
+		if err != nil {
+			errCh <- err
+			return
+		}
+		defer wp.Close()
+
+		fmt.Fprint(wp, "\x00")
+
+		r := bufio.NewReader(rp)
+		line, _, err := r.ReadLine()
+		if err != nil {
+			errCh <- err
+			return
+		}
+
+		var mode uint32
+		var size int64
+		var name string
+		if n, err := fmt.Sscanf(string(line), "C%o %d %s", &mode, &size, &name); err != nil {
+			errCh <- err
+			return
+		} else if n != 3 {
+			errCh <- errors.New(string(line))
+			return
+		}
+		_ = name
+
+		f, err := os.Create(dest)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		defer f.Close()
+
+		if err := f.Chmod(os.FileMode(mode)); err != nil {
+			errCh <- err
+			return
+		}
+
+		fmt.Fprint(wp, "\x00")
+
+		p := &progressWriter{f, 0, size, progress}
+		if _, err := io.Copy(p, io.LimitReader(r, size)); err != nil {
+			errCh <- err
+			return
+		}
+
+		fmt.Fprint(wp, "\x00")
+		close(errCh)
+	}()
+
+	err := session.Run(fmt.Sprintf("scp -qrf %s", src))
+	select {
+	case err := <-errCh:
+		return err
+	default:
+		return err
+	}
+}

--- a/tests.go
+++ b/tests.go
@@ -1,0 +1,557 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var duration time.Duration
+var concurrency string
+
+var tests = map[string]func(clusterName, dir string){
+	"kv_0":    kv0,
+	"kv_95":   kv95,
+	"ycsb_a":  ycsbA,
+	"ycsb_b":  ycsbB,
+	"ycsb_c":  ycsbC,
+	"nightly": nightly,
+	"splits":  splits,
+}
+
+var dirRE = regexp.MustCompile(`([^.]+)\.`)
+
+type testMetadata struct {
+	Bin     string
+	Cluster string
+	Nodes   []int
+	Env     string
+	Args    []string
+	Test    string
+	Date    string
+}
+
+type testRun struct {
+	Concurrency int
+	Elapsed     float64
+	Errors      int64
+	Ops         int64
+	OpsSec      float64
+	AvgLat      float64
+	P50Lat      float64
+	P95Lat      float64
+	P99Lat      float64
+}
+
+func loadTestRun(dir, name string) (*testRun, error) {
+	n, err := strconv.Atoi(name)
+	if err != nil {
+		return nil, nil
+	}
+	r := &testRun{Concurrency: n}
+
+	b, err := ioutil.ReadFile(filepath.Join(dir, name))
+	if err != nil {
+		return nil, err
+	}
+
+	const header = `_elapsed___errors_____ops(total)___ops/sec(cum)__avg(ms)__p50(ms)__p95(ms)__p99(ms)_pMax(ms)`
+	i := bytes.Index(b, []byte(header))
+	if i == -1 {
+		return nil, nil
+	}
+	b = b[i+len(header)+1:]
+
+	_, err = fmt.Fscanf(bytes.NewReader(b), " %fs %d %d %f %f %f %f %f",
+		&r.Elapsed, &r.Errors, &r.Ops, &r.OpsSec, &r.AvgLat, &r.P50Lat, &r.P95Lat, &r.P99Lat)
+	if err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+type testData struct {
+	Metadata testMetadata
+	Runs     []*testRun
+}
+
+func loadTestData(dir string) (*testData, error) {
+	d := &testData{}
+	if err := loadJSON(filepath.Join(dir, "metadata"), &d.Metadata); err != nil {
+		return nil, err
+	}
+
+	ents, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, e := range ents {
+		r, err := loadTestRun(dir, e.Name())
+		if err != nil {
+			return nil, err
+		}
+		if r != nil {
+			d.Runs = append(d.Runs, r)
+		}
+	}
+
+	sort.Slice(d.Runs, func(i, j int) bool {
+		return d.Runs[i].Concurrency < d.Runs[j].Concurrency
+	})
+	return d, nil
+}
+
+func (d *testData) exists(concurrency int) bool {
+	i := sort.Search(len(d.Runs), func(j int) bool {
+		return d.Runs[j].Concurrency >= concurrency
+	})
+	return i < len(d.Runs) && d.Runs[i].Concurrency == concurrency
+}
+
+func (d *testData) get(concurrency int) *testRun {
+	i := sort.Search(len(d.Runs), func(j int) bool {
+		return d.Runs[j].Concurrency >= concurrency
+	})
+	if i+1 >= len(d.Runs) {
+		return d.Runs[len(d.Runs)-1]
+	}
+	if i < 0 {
+		return d.Runs[0]
+	}
+	a := d.Runs[i]
+	b := d.Runs[i+1]
+	t := float64(concurrency-a.Concurrency) / float64(b.Concurrency-a.Concurrency)
+	return &testRun{
+		Concurrency: concurrency,
+		Elapsed:     a.Elapsed + float64(b.Elapsed-a.Elapsed)*t,
+		Ops:         a.Ops + int64(float64(b.Ops-a.Ops)*t),
+		OpsSec:      a.OpsSec + float64(b.OpsSec-a.OpsSec)*t,
+		AvgLat:      a.AvgLat + float64(b.AvgLat-a.AvgLat)*t,
+		P50Lat:      a.P50Lat + float64(b.P50Lat-a.P50Lat)*t,
+		P95Lat:      a.P95Lat + float64(b.P95Lat-a.P95Lat)*t,
+		P99Lat:      a.P99Lat + float64(b.P99Lat-a.P99Lat)*t,
+	}
+}
+
+func alignTestData(d1, d2 *testData) (*testData, *testData) {
+	if len(d1.Runs) == 0 || len(d2.Runs) == 0 {
+		return &testData{Metadata: d1.Metadata}, &testData{Metadata: d2.Metadata}
+	}
+
+	minConcurrency := d1.Runs[0].Concurrency
+	if c := d2.Runs[0].Concurrency; minConcurrency < c {
+		minConcurrency = c
+	}
+	maxConcurrency := d1.Runs[len(d1.Runs)-1].Concurrency
+	if c := d2.Runs[len(d2.Runs)-1].Concurrency; maxConcurrency > c {
+		maxConcurrency = c
+	}
+
+	var r1 []*testRun
+	var r2 []*testRun
+	for i := minConcurrency; i <= maxConcurrency; i++ {
+		if !d1.exists(i) || !d2.exists(i) {
+			continue
+		}
+		r1 = append(r1, d1.get(i))
+		r2 = append(r2, d2.get(i))
+	}
+
+	d1 = &testData{
+		Metadata: d1.Metadata,
+		Runs:     r1,
+	}
+	d2 = &testData{
+		Metadata: d2.Metadata,
+		Runs:     r2,
+	}
+	return d1, d2
+}
+
+func findTest(name string) (_ func(clusterName, dir string), dir string) {
+	fn := tests[name]
+	if fn != nil {
+		return fn, ""
+	}
+	m := dirRE.FindStringSubmatch(filepath.Base(name))
+	if len(m) != 2 {
+		return nil, ""
+	}
+	return tests[m[1]], name
+}
+
+func isTest(name string) bool {
+	fn, _ := findTest(name)
+	return fn != nil
+}
+
+func runTest(name, clusterName string) error {
+	fn, dir := findTest(name)
+	if fn == nil {
+		return fmt.Errorf("unknown test: %s", name)
+	}
+	fn(clusterName, dir)
+	return nil
+}
+
+func allTests() []string {
+	var r []string
+	for k := range tests {
+		r = append(r, k)
+	}
+	sort.Strings(r)
+	return r
+}
+
+func testCluster(name string) *syncedCluster {
+	c, err := newCluster(name, true /* reserveLoadGen */)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if c.loadGen == 0 {
+		log.Fatalf("%s: no load generator node specified", c.name)
+	}
+	return c
+}
+
+func clusterVersion(c *syncedCluster) string {
+	switch clusterType {
+	case "cockroach":
+		versions := c.cockroachVersions()
+		if len(versions) == 0 {
+			// TODO(peter): If we're running on existing test, rather than dying let
+			// the test upload the correct cockroach binary.
+			log.Fatalf("unable to determine cockroach version")
+		} else if len(versions) > 1 {
+			// TODO(peter): Rather than dying, allow the test to upload the version to
+			// run on each node.
+			log.Fatalf("mismatched cockroach versions: %v", versions)
+		}
+		for v := range versions {
+			return "cockroach-" + v
+		}
+
+	case "cassandra":
+		return "cassandra"
+
+	default:
+		log.Fatalf("unsupported cluster type: %s", clusterType)
+	}
+
+	panic("not reached")
+}
+
+func testDir(name, vers string) string {
+	dir := fmt.Sprintf("%s.%s", name, vers)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		log.Fatal(err)
+	}
+	return dir
+}
+
+func parseConcurrency(s string, numNodes int) (lo int, hi int, step int) {
+	// <lo>[-<hi>[/<step>]]
+	//
+	// If <step> is not specified, assuming numNodes. The <lo> and <hi> values
+	// are always multiplied by the number of nodes.
+
+	parts := strings.Split(s, "/")
+	switch len(parts) {
+	case 1:
+		step = numNodes
+	case 2:
+		var err error
+		step, err = strconv.Atoi(parts[1])
+		if err != nil {
+			log.Fatal(err)
+		}
+		s = parts[0]
+	}
+
+	parts = strings.Split(s, "-")
+	switch len(parts) {
+	case 1:
+		lo, err := strconv.Atoi(parts[0])
+		if err != nil {
+			log.Fatal(err)
+		}
+		return lo * numNodes, lo * numNodes, step
+	case 2:
+		lo, err := strconv.Atoi(parts[0])
+		if err != nil {
+			log.Fatal(err)
+		}
+		hi, err := strconv.Atoi(parts[1])
+		if err != nil {
+			log.Fatal(err)
+		}
+		return lo * numNodes, hi * numNodes, step
+	default:
+		log.Fatalf("unable to parse concurrency setting: %s", s)
+	}
+	return 0, 0, 0
+}
+
+func getBin(c *syncedCluster, dir string) {
+	if clusterType == "cockroach" {
+		bin := filepath.Join(dir, "cockroach")
+		if _, err := os.Stat(bin); err == nil {
+			return
+		}
+		t := *c
+		t.nodes = t.nodes[:1]
+		t.get("./cockroach", bin)
+	}
+}
+
+func putBin(c *syncedCluster, dir string) error {
+	if clusterType == "cockroach" {
+		bin := filepath.Join(dir, "cockroach")
+		if _, err := os.Stat(bin); err != nil {
+			return err
+		}
+		c.put(bin, "./cockroach")
+	}
+	return nil
+}
+
+func kvTest(clusterName, testName, dir, cmd string) {
+	var existing *testMetadata
+	if dir != "" {
+		existing = &testMetadata{}
+		if err := loadJSON(filepath.Join(dir, "metadata"), existing); err != nil {
+			log.Fatal(err)
+		}
+		clusterName = existing.Cluster
+		nodeArgs = existing.Args
+	}
+
+	c := testCluster(clusterName)
+	m := testMetadata{
+		Bin:     clusterVersion(c),
+		Cluster: c.name,
+		Nodes:   c.nodes,
+		Env:     c.env,
+		Args:    c.args,
+		Test:    fmt.Sprintf("%s --duration=%s --concurrency=%%d", cmd, duration),
+		Date:    time.Now().Format("2006-01-02T15_04_05"),
+	}
+	if existing == nil {
+		dir = testDir(testName, m.Bin)
+		saveJSON(filepath.Join(dir, "metadata"), m)
+	} else {
+		if m.Bin != existing.Bin {
+			if err := putBin(c, dir); err != nil {
+				log.Fatalf("binary changed: %s != %s\n%s", m.Bin, existing.Bin, err)
+			}
+		}
+		m.Nodes = existing.Nodes
+		m.Env = existing.Env
+	}
+	fmt.Printf("%s: %s\n", c.name, dir)
+	getBin(c, dir)
+
+	lo, hi, step := parseConcurrency(concurrency, len(c.serverNodes()))
+	for concurrency := lo; concurrency <= hi; concurrency += step {
+		runName := fmt.Sprint(concurrency)
+		if run, err := loadTestRun(dir, runName); err == nil && run != nil {
+			continue
+		}
+
+		err := func() error {
+			f, err := os.Create(filepath.Join(dir, runName))
+			if err != nil {
+				log.Fatal(err)
+			}
+			defer f.Close()
+			c.wipe()
+			c.start()
+			cmd := fmt.Sprintf(m.Test, concurrency)
+			stdout := io.MultiWriter(f, os.Stdout)
+			stderr := io.MultiWriter(f, os.Stderr)
+			return c.runLoad(cmd, stdout, stderr)
+		}()
+		if err != nil {
+			if !isSigKill(err) {
+				fmt.Printf("%s\n", err)
+			}
+			break
+		}
+	}
+	c.stop()
+}
+
+func kv0(clusterName, dir string) {
+	kvTest(clusterName, "kv_0", dir, "./kv --read-percent=0 --splits=1000")
+}
+
+func kv95(clusterName, dir string) {
+	kvTest(clusterName, "kv_95", dir, "./kv --read-percent=95 --splits=1000")
+}
+
+func ycsbA(clusterName, dir string) {
+	kvTest(clusterName, "ycsb_a", dir, "./ycsb --workload=A --splits=1000 --cassandra-replication=3")
+}
+
+func ycsbB(clusterName, dir string) {
+	kvTest(clusterName, "ycsb_b", dir, "./ycsb --workload=B --splits=1000 --cassandra-replication=3")
+}
+
+func ycsbC(clusterName, dir string) {
+	kvTest(clusterName, "ycsb_c", dir, "./ycsb --workload=C --splits=1000 --cassandra-replication=3")
+}
+
+func nightly(clusterName, dir string) {
+	var existing *testMetadata
+	if dir != "" {
+		existing = &testMetadata{}
+		if err := loadJSON(filepath.Join(dir, "metadata"), existing); err != nil {
+			log.Fatal(err)
+		}
+		clusterName = existing.Cluster
+		nodeArgs = existing.Args
+	}
+
+	cmds := []struct {
+		name string
+		cmd  string
+	}{
+		{"kv_0", "./kv --read-percent=0 --splits=1000 --concurrency=384 --duration=10m"},
+		{"kv_95", "./kv --read-percent=95 --splits=1000 --concurrency=384 --duration=10m"},
+		// TODO(tamird/petermattis): this configuration has been observed to hang
+		// indefinitely. Re-enable when it is more reliable.
+		//
+		// {"splits", "./kv --read-percent=0 --splits=100000 --concurrency=384 --max-ops=1"},
+	}
+
+	c := testCluster(clusterName)
+	m := testMetadata{
+		Bin:     clusterVersion(c),
+		Cluster: c.name,
+		Nodes:   c.nodes,
+		Env:     c.env,
+		Args:    c.args,
+		Test:    "nightly",
+		Date:    time.Now().Format("2006-01-02T15_04_05"),
+	}
+	if existing == nil {
+		dir = testDir("nightly", m.Bin)
+		saveJSON(filepath.Join(dir, "metadata"), m)
+	} else {
+		if m.Bin != existing.Bin {
+			if err := putBin(c, dir); err != nil {
+				log.Fatalf("cockroach binary changed: %s != %s\n%s", m.Bin, existing.Bin, err)
+			}
+		}
+		m.Nodes = existing.Nodes
+		m.Env = existing.Env
+	}
+	fmt.Printf("%s: %s\n", c.name, dir)
+	getBin(c, dir)
+
+	for _, cmd := range cmds {
+		runName := fmt.Sprint(cmd.name)
+		if run, err := loadTestRun(dir, runName); err == nil && run != nil {
+			continue
+		}
+
+		err := func() error {
+			f, err := os.Create(filepath.Join(dir, runName))
+			if err != nil {
+				log.Fatal(err)
+			}
+			defer f.Close()
+			c.wipe()
+			c.start()
+			stdout := io.MultiWriter(f, os.Stdout)
+			stderr := io.MultiWriter(f, os.Stderr)
+			return c.runLoad(cmd.cmd, stdout, stderr)
+		}()
+		if err != nil {
+			if !isSigKill(err) {
+				fmt.Printf("%s\n", err)
+			}
+			break
+		}
+	}
+	c.stop()
+}
+
+func splits(clusterName, dir string) {
+	var existing *testMetadata
+	if dir != "" {
+		existing = &testMetadata{}
+		if err := loadJSON(filepath.Join(dir, "metadata"), existing); err != nil {
+			log.Fatal(err)
+		}
+		clusterName = existing.Cluster
+		nodeArgs = existing.Args
+	}
+
+	const cmd = "./kv --splits=500000 --concurrency=384 --max-ops=1"
+	c := testCluster(clusterName)
+	m := testMetadata{
+		Bin:     clusterVersion(c),
+		Cluster: c.name,
+		Nodes:   c.nodes,
+		Env:     c.env,
+		Args:    c.args,
+		Test:    "splits",
+		Date:    time.Now().Format("2006-01-02T15_04_05"),
+	}
+	if existing == nil {
+		dir = testDir("splits", m.Bin)
+		saveJSON(filepath.Join(dir, "metadata"), m)
+	} else {
+		if m.Bin != existing.Bin {
+			if err := putBin(c, dir); err != nil {
+				log.Fatalf("cockroach binary changed: %s != %s\n%s", m.Bin, existing.Bin, err)
+			}
+		}
+		m.Nodes = existing.Nodes
+		m.Env = existing.Env
+	}
+	fmt.Printf("%s: %s\n", c.name, dir)
+	getBin(c, dir)
+
+	for i := 1; i <= 100; i++ {
+		runName := fmt.Sprint(i)
+		if run, err := loadTestRun(dir, runName); err == nil && run != nil {
+			continue
+		}
+
+		err := func() error {
+			f, err := os.Create(filepath.Join(dir, runName))
+			if err != nil {
+				log.Fatal(err)
+			}
+			defer f.Close()
+			c.wipe()
+			c.start()
+			stdout := io.MultiWriter(f, os.Stdout)
+			stderr := io.MultiWriter(f, os.Stderr)
+			if err := c.runLoad(cmd, stdout, stderr); err != nil {
+				return err
+			}
+			c.stop()
+			return nil
+		}()
+		if err != nil {
+			if !isSigKill(err) {
+				fmt.Printf("%s\n", err)
+			}
+			break
+		}
+	}
+	c.stop()
+}

--- a/upload.go
+++ b/upload.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+const (
+	awsAccessKeyIDKey     = "AWS_ACCESS_KEY_ID"
+	awsSecretAccessKeyKey = "AWS_SECRET_ACCESS_KEY"
+)
+
+func upload(args []string) error {
+	backend := "s3"
+	switch n := len(args); n {
+	case 0:
+		return fmt.Errorf("no test directory specified")
+	case 1:
+		// Default to S3 backend.
+	case 2:
+		backend = args[1]
+	default:
+		return fmt.Errorf("too many arguments (expected 2): %s", args)
+	}
+
+	testdir := args[0]
+
+	if backend != "s3" {
+		return fmt.Errorf("invalid backend %s (valid backends: s3)", backend)
+	}
+
+	if _, ok := os.LookupEnv(awsAccessKeyIDKey); !ok {
+		log.Fatalf("AWS access key ID environment variable %s is not set", awsAccessKeyIDKey)
+	}
+	if _, ok := os.LookupEnv(awsSecretAccessKeyKey); !ok {
+		log.Fatalf("AWS secret access key environment variable %s is not set", awsSecretAccessKeyKey)
+	}
+
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String("us-east-1"),
+	})
+	if err != nil {
+		log.Fatalf("AWS session: %s", err)
+	}
+	svc := s3.New(sess)
+
+	bucketName := "cockroachlabs"
+
+	tarpath := testdir + ".tgz"
+	cmd := exec.Command("tar", "-czf", tarpath, testdir)
+	if err := cmd.Run(); err != nil {
+		log.Fatalf("%s: %s", cmd, err)
+	}
+
+	f, err := os.Open(tarpath)
+	if err != nil {
+		log.Fatalf("os.Open(%s): %s", tarpath, err)
+	}
+
+	key := "roachperf/" + tarpath
+
+	putObjectInput := s3.PutObjectInput{
+		Bucket: &bucketName,
+		Key:    &key,
+		Body:   f,
+	}
+	if _, err := svc.PutObject(&putObjectInput); err != nil {
+		log.Fatalf("s3 upload %s: %s", tarpath, err)
+	}
+	fmt.Printf("Uploaded %s to %s/%s\n", tarpath, bucketName, key)
+
+	if err := f.Close(); err != nil {
+		log.Fatal(err)
+	}
+
+	if err := os.Remove(tarpath); err != nil {
+		log.Fatal(err)
+	}
+	return nil
+}

--- a/web.go
+++ b/web.go
@@ -1,0 +1,371 @@
+package main
+
+import (
+	"fmt"
+	"html/template"
+	"io/ioutil"
+	"os/exec"
+)
+
+func web(dirs []string) error {
+	// TODO(peter): visualize the output of a single test run, showing
+	// performance and latency over time.
+	switch n := len(dirs); n {
+	case 0:
+		return fmt.Errorf("no test directory specified")
+	case 1, 2:
+		d1, err := loadTestData(dirs[0])
+		if err != nil {
+			return err
+		}
+		if n == 1 {
+			return web1(d1)
+		}
+		d2, err := loadTestData(dirs[1])
+		if err != nil {
+			return err
+		}
+		return web2(d1, d2)
+	default:
+		ds := make([]*testData, len(dirs))
+		for i, dir := range dirs {
+			d, err := loadTestData(dir)
+			if err != nil {
+				return err
+			}
+
+			ds[i] = d
+		}
+		return webBulk(ds)
+	}
+}
+
+func webApply(m interface{}) error {
+	t, err := template.New("web").Parse(webHTML)
+	if err != nil {
+		return err
+	}
+	f, err := ioutil.TempFile("", "web")
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if err := t.Execute(f, m); err != nil {
+		return err
+	}
+	return exec.Command("open", f.Name()).Run()
+}
+
+type series struct {
+	TargetAxisIndex int
+	Color           string
+	LineDashStyle   []int
+}
+
+func web1(d *testData) error {
+	data := []interface{}{
+		[]interface{}{"concurrency", "ops/sec", "avg latency", "99%-tile latency"},
+	}
+	for _, r := range d.Runs {
+		data = append(data, []interface{}{
+			r.Concurrency, r.OpsSec, r.AvgLat, r.P99Lat,
+		})
+	}
+
+	m := map[string]interface{}{
+		"data":  data,
+		"haxis": "concurrency",
+		"vaxes": []string{"ops/sec", "latency (ms)"},
+		"series": []series{
+			{0, "#ff0000", []int{}},
+			{1, "#ff0000", []int{2, 2}},
+			{1, "#ff0000", []int{4, 4}},
+		},
+	}
+
+	return webApply(m)
+}
+
+func web2(d1, d2 *testData) error {
+	d1, d2 = alignTestData(d1, d2)
+
+	data := []interface{}{
+		[]interface{}{
+			"concurrency",
+			fmt.Sprintf("ops/sec (%s)", d1.Metadata.Bin),
+			fmt.Sprintf("99%%-lat (%s)", d1.Metadata.Bin),
+			fmt.Sprintf("ops/sec (%s)", d2.Metadata.Bin),
+			fmt.Sprintf("99%%-lat (%s)", d2.Metadata.Bin),
+		},
+	}
+	for i := range d1.Runs {
+		r1 := d1.Runs[i]
+		r2 := d2.Runs[i]
+		data = append(data, []interface{}{
+			r1.Concurrency, r1.OpsSec, r1.P99Lat, r2.OpsSec, r2.P99Lat,
+		})
+	}
+
+	m := map[string]interface{}{
+		"data":  data,
+		"haxis": "concurrency",
+		"vaxes": []string{"ops/sec", "latency (ms)"},
+		"series": []series{
+			{0, "#ff0000", []int{}},
+			{1, "#ff0000", []int{2, 2}},
+			{0, "#0000ff", []int{}},
+			{1, "#0000ff", []int{2, 2}},
+		},
+	}
+	return webApply(m)
+}
+
+const webHTML = `<html>
+  <head>
+    <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
+    <script type="text/javascript">
+      google.charts.load('current', {'packages':['corechart']});
+      google.charts.setOnLoadCallback(drawChart);
+
+      function drawChart() {
+        var data = google.visualization.arrayToDataTable([
+          {{- range .data }}
+          {{ . }},
+          {{- end}}
+        ]);
+
+        var options = {
+          legend: { position: 'top', alignment: 'center', textStyle: {fontSize: 12}, maxLines: 5 },
+          crosshair: { trigger: 'both', opacity: 0.35 },
+          series: {
+            {{- range $i, $e := .series }}
+            {{ $i }}: {targetAxisIndex: {{- $e.TargetAxisIndex }}, color: {{ $e.Color }}, lineDashStyle: {{ $e.LineDashStyle }}},
+            {{- end }}
+          },
+          vAxes: {
+            {{- range $i, $e := .vaxes }}
+            {{ $i }}: {title: {{ $e }}},
+            {{- end }}
+          },
+          hAxis: {
+            title: {{ .haxis }},
+          },
+        };
+        var chart = new google.visualization.LineChart(document.getElementById('chart'));
+        chart.draw(data, options);
+      }
+    </script>
+  </head>
+  <body>
+    <div id="chart" style="width: 800; height: 600"></div>
+  </body>
+</html>
+`
+
+func webBulk(m []*testData) error {
+	t, err := template.New("web").Parse(webHTMLBulk)
+	if err != nil {
+		return err
+	}
+	f, err := ioutil.TempFile("", "web")
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if err := t.Execute(f, m); err != nil {
+		return err
+	}
+	return exec.Command("open", f.Name()).Run()
+}
+
+const webHTMLBulk = `<html>
+  <head>
+  </head>
+    <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
+    <script>
+      google.charts.load('current', {'packages':['corechart']});
+      google.charts.setOnLoadCallback(renderOverview);
+
+      var SUMMARY_CONCURRENCY = 384;
+
+      var tests = [
+      {{- range $j, $d := . }}{{ if $j }},{{ end }}
+        {
+          "metadata": {
+            "bin": {{ .Metadata.Bin }},
+            "cluster": {{ .Metadata.Cluster }},
+            "nodes": {{ .Metadata.Nodes }},
+            "env": {{ .Metadata.Env }},
+            "args": {{ .Metadata.Args }},
+            "test": {{ .Metadata.Test }},
+            "date": {{ .Metadata.Date }}
+          },
+          "runs": [
+          {{- range $i, $e := .Runs }}{{ if $i }},{{ end }}
+            {
+              "concurrency": {{ $e.Concurrency }},
+              "elapsed": {{ $e.Elapsed }},
+              "errors": {{ $e.Errors }},
+              "ops": {{ $e.Ops }},
+              "opsSec": {{ $e.OpsSec }},
+              "avgLat": {{ $e.AvgLat }},
+              "p50Lat": {{ $e.P50Lat }},
+              "p95Lat": {{ $e.P95Lat }},
+              "p99Lat": {{ $e.P99Lat }}
+            }
+          {{- end }}
+          ]
+        }
+      {{- end }}
+      ];
+
+      var summaryOptions = {
+        legend: { position: 'top', alignment: 'center', textStyle: {fontSize: 12}, maxLines: 5 },
+        crosshair: { trigger: 'both', opacity: 0.35 },
+        series: {
+          "0":{targetAxisIndex: 0, color:"#ff0000", lineDashStyle: []},
+          "1":{targetAxisIndex: 1, color:"#ff0000", lineDashStyle: [2, 2]},
+          "2":{targetAxisIndex: 1, color:"#ff0000", lineDashStyle: [4, 4]}
+        },
+        vAxes: {"0":{title:"ops/sec"}, "1":{title:"latency (ms)"}},
+        hAxis: {
+          title: "version",
+        },
+      };
+
+      var oneTestOptions = {
+        legend: { position: 'top', alignment: 'center', textStyle: {fontSize: 12}, maxLines: 5 },
+        crosshair: { trigger: 'both', opacity: 0.35 },
+        series: {
+          "0":{targetAxisIndex: 0, color:"#ff0000", lineDashStyle: []},
+          "1":{targetAxisIndex: 1, color:"#ff0000", lineDashStyle: [2, 2]},
+          "2":{targetAxisIndex: 1, color:"#ff0000", lineDashStyle: [4, 4]}
+        },
+        vAxes: {"0":{title:"ops/sec"}, "1":{title:"latency (ms)"}},
+        hAxis: {
+          title: "concurrency",
+        },
+      };
+
+      var twoTestOptions = {
+        legend: { position: 'top', alignment: 'center', textStyle: {fontSize: 12}, maxLines: 5 },
+        crosshair: { trigger: 'both', opacity: 0.35 },
+        series: {
+          "0":{targetAxisIndex: 0, color:"#ff0000", lineDashStyle: []},
+          "1":{targetAxisIndex: 1, color:"#ff0000", lineDashStyle: [2, 2]},
+          "2":{targetAxisIndex: 0, color:"#0000ff", lineDashStyle: []},
+          "3":{targetAxisIndex: 1, color:"#0000ff", lineDashStyle: [2, 2]}
+        },
+        vAxes: {"0":{title:"ops/sec"}, "1":{title:"latency (ms)"}},
+        hAxis: {
+          title: "concurrency",
+        },
+      };
+
+      var compare = [];
+
+      function renderOverview() {
+        var summary = tests
+          .map(function (t) {
+            return {
+              bin: t.metadata.bin,
+              runs: t.runs.filter(function (r) { return r.concurrency === SUMMARY_CONCURRENCY; })
+            };
+          })
+          .filter(function (t) { return t.runs.length; })
+          .map(function (t) { return { bin: t.bin, run: t.runs[0] }; });
+
+        var test;
+
+        var source = [["version", "ops/sec", "avg latency", "99%-ile latency"]];
+        for (var i = 0; i < summary.length; i++) {
+          test = summary[i];
+          source.push([test.bin, test.run.opsSec, test.run.avgLat, test.run.p99Lat]);
+        }
+
+        var data = google.visualization.arrayToDataTable(source);
+        var chart = new google.visualization.LineChart(document.getElementById('chart'));
+        chart.draw(data, summaryOptions);
+
+        document.getElementById("label").innerHTML = 'overview';
+      }
+
+      function renderChart(i) {
+        var runs = tests[i].runs;
+		var bin = tests[i].metadata.bin;
+        var run;
+
+        var source = [["concurrency", "ops/sec", "avg latency", "99%-ile latency"]];
+        for (var i = 0; i < runs.length; i++) {
+          run = runs[i];
+          source.push([run.concurrency, run.opsSec, run.avgLat, run.p99Lat]);
+        }
+
+        var data = google.visualization.arrayToDataTable(source);
+        var chart = new google.visualization.LineChart(document.getElementById('chart'));
+        chart.draw(data, oneTestOptions);
+
+        document.getElementById("label").innerHTML = bin;
+      }
+
+      function compareChart(i) {
+        compare.push(i);
+
+        if (compare.length > 2) compare = compare.slice(compare.length - 2);
+
+        if (compare.length !== 2) return;
+
+        var d1 = tests[compare[0]], d2 = tests[compare[1]];
+        var bin1 = d1.metadata.bin, bin2 = d2.metadata.bin;
+
+        var byConcurrency1 = {}, byConcurrency2 = {};
+
+        var concurrencies1 = d1.runs.map(function (r) {
+          byConcurrency1[r.concurrency] = r;
+          return r.concurrency;
+        });
+        var concurrencies2 = d2.runs.map(function (r) {
+          byConcurrency2[r.concurrency] = r;
+          return r.concurrency;
+        });
+
+        var concurrencies = concurrencies1.filter(function (c) { return concurrencies2.indexOf(c) >= 0; });
+
+        var concurrency, run1, run2;
+
+        var source = [["concurrency", "ops/sec (" + bin1 + ")", "99%-ile (" + bin1 + ")", "ops/sec (" + bin2 + ")", "99%-ile (" + bin2 + ")"]];
+        for (var i = 0; i < concurrencies.length; i++) {
+          concurrency = concurrencies[i];
+          run1 = byConcurrency1[concurrency];
+          run2 = byConcurrency2[concurrency];
+
+          source.push([concurrency, run1.opsSec, run1.p99Lat, run2.opsSec, run2.p99Lat]);
+        }
+
+        var data = google.visualization.arrayToDataTable(source);
+        var chart = new google.visualization.LineChart(document.getElementById('chart'));
+        chart.draw(data, twoTestOptions);
+
+        document.getElementById("label").innerHTML = bin1 + ' vs. ' + bin2;
+      }
+    </script>
+  <body>
+    <h2>performance review</h2>
+	<p>Chart a single test by clicking "single".  Compare two by clicking "compare" on each.</p>
+    <h3>available tests</h3>
+    <ul>
+      <li><a href="#" onClick="renderOverview()">overview</a></li>
+    {{- range $i, $e := . }}
+      <li>
+        {{ .Metadata.Bin }}
+        {{- if .Metadata.Date }} ({{ .Metadata.Date }}){{ end }}
+        - <a href="#" onClick="renderChart({{ $i }});">single</a>
+        - <a href="#" onClick="compareChart({{ $i }});">compare</a>
+      </li>
+    {{- end }}
+    </ul>
+	<h3 id="label"></h3>
+    <div id="chart" style="width: 800; height: 600"></div>
+  </body>
+</html>
+`

--- a/writer.go
+++ b/writer.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+)
+
+type uiWriter struct {
+	buf       bytes.Buffer
+	lineCount int
+}
+
+func (w *uiWriter) Flush(out io.Writer) error {
+	if len(w.buf.Bytes()) == 0 {
+		return nil
+	}
+	w.clearLines(out)
+
+	for _, b := range w.buf.Bytes() {
+		if b == '\n' {
+			w.lineCount++
+		}
+	}
+	_, err := out.Write(w.buf.Bytes())
+	w.buf.Reset()
+	return err
+}
+
+func (w *uiWriter) Write(b []byte) (n int, err error) {
+	return w.buf.Write(b)
+}
+
+func (w *uiWriter) clearLines(out io.Writer) {
+	fmt.Fprint(out, strings.Repeat("\033[1A\033[2K\r", w.lineCount))
+	w.lineCount = 0
+}


### PR DESCRIPTION
Merge roachperf into roachprod. Roachprod is now a one-stop shop for
managing CockroachDB clusters.

Any invocation of roachperf is now a valid invocation of roachprod, with
the following caveats:

  * roachperf commands which took a cluster name as an argument, like
    `roachperf USER-CLUSTER start`, have been reordered. The equivalent
    roachprod command is `roachprod start USER-CLUSTER`.

  * To make room for roachper's status command, `roachprod status` has
    been renamed to `roachprod list`. The prior behavior of `roachprod
    list` is available as `roachprod list --details`.

In the interest of incremental improvement, this is the minimal change
necessary to make this merge possible. More cleanup is in order.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/26)
<!-- Reviewable:end -->
