### PR TITLE
Prototype of nightly test infra

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,16 +2,167 @@
 
 
 [[projects]]
+  name = "github.com/Shopify/sarama"
+  packages = ["."]
+  revision = "3b1b38866a79f06deddf0487d5c27ba0697ccd65"
+  version = "v1.15.0"
+
+[[projects]]
+  name = "github.com/apache/thrift"
+  packages = ["lib/go/thrift"]
+  revision = "327ebb6c2b6df8bf075da02ef45a2a034e9b79ba"
+  version = "0.11.0"
+
+[[projects]]
+  name = "github.com/certifi/gocertifi"
+  packages = ["."]
+  revision = "deb3ae2ef2610fde3330947281941c562861188b"
+  version = "2018.01.18"
+
+[[projects]]
+  name = "github.com/cockroachdb/cockroach"
+  packages = ["pkg/build","pkg/settings","pkg/util/binfetcher","pkg/util/caller","pkg/util/color","pkg/util/envutil","pkg/util/fileutil","pkg/util/humanizeutil","pkg/util/log","pkg/util/log/logflags","pkg/util/syncutil","pkg/util/timeutil","pkg/util/tracing"]
+  revision = "098b426bd50d40d90a3ff02f9fe7df738629629f"
+  version = "v2.0-alpha.20180122"
+
+[[projects]]
+  name = "github.com/davecgh/go-spew"
+  packages = ["spew"]
+  revision = "346938d642f2ec3594ed81d874461961cd0faa76"
+  version = "v1.1.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/dustin/go-humanize"
+  packages = ["."]
+  revision = "bb3d318650d48840a39aa21a027c6630e198e626"
+
+[[projects]]
+  name = "github.com/eapache/go-resiliency"
+  packages = ["breaker"]
+  revision = "6800482f2c813e689c88b7ed3282262385011890"
+  version = "v1.0.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/eapache/go-xerial-snappy"
+  packages = ["."]
+  revision = "bb955e01b9346ac19dc29eb16586c90ded99a98c"
+
+[[projects]]
+  name = "github.com/eapache/queue"
+  packages = ["."]
+  revision = "44cc805cf13205b55f69e14bcb69867d1ae92f98"
+  version = "v1.1.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/getsentry/raven-go"
+  packages = ["."]
+  revision = "221b2b44fb33f84ed3ea13f3aed62ff48c85636b"
+  source = "https://github.com/cockroachdb/raven-go"
+
+[[projects]]
+  name = "github.com/go-logfmt/logfmt"
+  packages = ["."]
+  revision = "390ab7935ee28ec6b286364bba9b4dd6410cb3d5"
+  version = "v0.3.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/gogo/protobuf"
+  packages = ["proto","sortkeys","types"]
+  revision = "26de2f9a7d3b1826f275e7a97c8cad5080589426"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/golang/protobuf"
+  packages = ["proto","protoc-gen-go/descriptor","ptypes","ptypes/any","ptypes/duration","ptypes/timestamp"]
+  revision = "925541529c1fa6821df4e44ce2723319eb2be768"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/golang/snappy"
+  packages = ["."]
+  revision = "553a641470496b2327abcac10b36396bd98e45c9"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/hashicorp/go-version"
+  packages = ["."]
+  revision = "4fe82ae3040f80a03d04d2cccb5606a626b8e1ee"
+
+[[projects]]
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
   version = "v1.0"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/kr/logfmt"
+  packages = ["."]
+  revision = "b84e30acd515aadc4b783ad4ff83aff3299bdfe0"
+
+[[projects]]
+  name = "github.com/lightstep/lightstep-tracer-go"
+  packages = [".","collectorpb","lightstep_thrift","lightsteppb","thrift_0_9_2/lib/go/thrift"]
+  revision = "f9f54d495e5c6752b58fae6b66a5cb1107e17b29"
+  version = "v0.15.2"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/opentracing-contrib/go-observer"
+  packages = ["."]
+  revision = "a52f2342449246d5bcc273e65cbdcfa5f7d6c63c"
+
+[[projects]]
+  name = "github.com/opentracing/opentracing-go"
+  packages = [".","ext","log"]
+  revision = "1949ddbfd147afd4d964a9f00b24eb291e0e7c38"
+  version = "v1.0.2"
+
+[[projects]]
+  name = "github.com/openzipkin/zipkin-go-opentracing"
+  packages = [".","flag","thrift/gen-go/scribe","thrift/gen-go/zipkincore","types","wire"]
+  revision = "45e90b00710a4c34a1a7d8a78d90f9b010b0bd4d"
+  version = "v0.3.2"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/petermattis/goid"
+  packages = ["."]
+  revision = "176e84a949d354dcef722e602b312b1a75bacddc"
+
+[[projects]]
+  name = "github.com/pierrec/lz4"
+  packages = ["."]
+  revision = "2fcda4cb7018ce05a25959d2fe08c83e3329f169"
+  version = "v1.1"
+
+[[projects]]
+  name = "github.com/pierrec/xxHash"
+  packages = ["xxHash32"]
+  revision = "f051bb7f1d1aaf1b5a665d74fb6b0217712c69f7"
+  version = "v0.1.1"
+
+[[projects]]
   name = "github.com/pkg/errors"
   packages = ["."]
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/rcrowley/go-metrics"
+  packages = ["."]
+  revision = "8732c616f52954686704c8645fe1a9d59e9df7c1"
+
+[[projects]]
+  name = "github.com/sasha-s/go-deadlock"
+  packages = ["."]
+  revision = "03d40e5dbd5488667a13b3c2600b2f7c2886f02f"
+  version = "v0.2.0"
 
 [[projects]]
   name = "github.com/spf13/cobra"
@@ -28,7 +179,7 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = ["context"]
+  packages = ["context","http2","http2/hpack","idna","internal/timeseries","lex/httplex","trace"]
   revision = "0ed95abb35c445290478a5348a7b38bb154135fd"
 
 [[projects]]
@@ -36,6 +187,30 @@
   name = "golang.org/x/sync"
   packages = ["errgroup"]
   revision = "fd80eb99c8f653c847d294a001bdf2a3a6f768f5"
+
+[[projects]]
+  branch = "master"
+  name = "golang.org/x/sys"
+  packages = ["unix","windows"]
+  revision = "ff2a66f350cefa5c93a634eadb5d25bb60c85a9c"
+
+[[projects]]
+  branch = "master"
+  name = "golang.org/x/text"
+  packages = ["collate","collate/build","internal/colltab","internal/gen","internal/tag","internal/triegen","internal/ucd","language","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable"]
+  revision = "e19ae1496984b1c655b8044a65c0300a3c878dd3"
+
+[[projects]]
+  branch = "master"
+  name = "google.golang.org/genproto"
+  packages = ["googleapis/api/annotations","googleapis/rpc/status"]
+  revision = "4eb30f4778eed4c258ba66527a0d4f9ec8a36c45"
+
+[[projects]]
+  name = "google.golang.org/grpc"
+  packages = [".","balancer","balancer/base","balancer/roundrobin","codes","connectivity","credentials","encoding","grpclb/grpc_lb_v1/messages","grpclog","internal","keepalive","metadata","naming","peer","resolver","resolver/dns","resolver/passthrough","stats","status","tap","transport"]
+  revision = "6b51017f791ae1cfbec89c52efdf444b13b550ef"
+  version = "v1.9.2"
 
 [[projects]]
   branch = "v3"
@@ -52,6 +227,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "7616765e9b46b97a6c1b6fc5a4dede1baefc2d17d1e2633826b39b2d50c4160c"
+  inputs-digest = "d8855ff5c69594b5c38a810befe89cbe4bccb83f6f3d05c0f8ed634268093ab6"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/infra_helpers.go
+++ b/infra_helpers.go
@@ -7,6 +7,10 @@ import (
 	"github.com/cockroachdb/roachprod/roachprodng"
 	"context"
 	"time"
+	"github.com/cockroachdb/cockroach/pkg/util/binfetcher"
+	"os/user"
+	"log"
+	"github.com/pkg/errors"
 )
 
 func SetupTestingClusterSettings(db string) error {
@@ -38,3 +42,66 @@ func SomeCLITest(ctx context.Context, c *roachprodng.Cluster) error {
 	// Does something that users can run against their roachprod clusters.
 	return nil
 }
+
+type BinarySource interface {
+	Download(ctx context.Context, binaries ...string) (map[string]string, error)
+}
+
+type RemoteSource binfetcher.Options
+
+var _ BinarySource = RemoteSource{}
+
+func (src RemoteSource) Download(ctx context.Context, binNames ...string) (map[string]string, error) {
+	m := map[string]string{}
+	for _, binName := range binNames {
+		src.Binary = binName
+		loc, err := binfetcher.Download(ctx, binfetcher.Options(src))
+		if err != nil {
+			return nil, errors.Wrapf(err, "while downloading %s", binName)
+		}
+		m[binName] = loc
+	}
+	return m, nil
+}
+
+// LocalDevelopmentSource checks $GOPATH/src/github.com/cockroachdb/cockroach
+// for the requested binary and, if found, prefers that over downloading it.
+// Note that this won't check that the binary was compiled for the right
+// architecture.
+type LocalDevelopmentSource RemoteSource
+
+var _ BinarySource = LocalDevelopmentSource{}
+
+func (src LocalDevelopmentSource) Download(ctx context.Context, binNames ...string) (map[string]string, error) {
+	gopath := os.Getenv("GOPATH")
+	if gopath == "" {
+		user, err := user.Current()
+		if err != nil {
+			return nil, err
+		}
+		gopath = filepath.Join(user.HomeDir, "go")
+	}
+
+	localRepo := filepath.Join(gopath, "src/github.com/cockroachdb/cockroach")
+
+	m := map[string]string{}
+	for _, binName := range binNames {
+		localBin := filepath.Join(localRepo, binName)
+		if _, err := os.Stat(localBin); err == nil {
+			log.Printf("using %s from %s", binName, localBin)
+			m[binName] = localBin
+			break
+		} else if !os.IsNotExist(err) {
+			return nil, errors.Wrapf(err, "stat %s", localBin)
+		}
+		log.Printf("%s not found in local repo; downloading", binName)
+		loc, err := RemoteSource(src).Download(ctx, binName)
+		if err != nil {
+			return nil, err
+		}
+		m[binName] = loc[binName]
+	}
+
+	return m, nil
+}
+

--- a/infra_helpers.go
+++ b/infra_helpers.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/cockroachdb/roachprod/roachprodng"
+	"context"
+	"time"
+)
+
+func SetupTestingClusterSettings(db string) error {
+	// TODO
+	return nil
+}
+
+func RunNightlyPerf(ctx context.Context, cmd string, opts TestHelperOptions) error {
+	// TODO
+	return nil
+}
+
+func SetupNightlyCluster(opts TestHelperOptions) (*roachprodng.Cluster, error) {
+	// TODO
+	return &roachprodng.Cluster{}, nil
+}
+
+type TestHelperOptions struct {
+	Nodes, Runners int
+	Expiration     time.Duration
+}
+
+func fileHelper(name string) (*os.File, error) {
+	const artifactsDir = "./artifacts"
+	return os.Create(filepath.Join(artifactsDir, name))
+}
+
+func SomeCLITest(ctx context.Context, c *roachprodng.Cluster) error {
+	// Does something that users can run against their roachprod clusters.
+	return nil
+}

--- a/infra_test.go
+++ b/infra_test.go
@@ -1,0 +1,290 @@
+package main
+
+import (
+	"os"
+
+	"context"
+	"testing"
+	"time"
+
+	"golang.org/x/sync/errgroup" // TODO: vendor
+
+	"github.com/cockroachdb/cockroach/pkg/util/binfetcher"
+	"github.com/cockroachdb/roachprod/monitor"
+	"github.com/cockroachdb/roachprod/roachprodng"
+	"github.com/pkg/errors"
+)
+
+// TestPartitioningRoachmartBareBones runs a three-locality geo-distributed
+// cluster and on it, the `roachmart` workload.
+//
+// NB: this test serves as an example to show the low-level APIs. With enough
+// similar tests, it's likely that a common abstraction for geo-distributed
+// testing emerges.
+func TestPartitioningRoachmartBareBones(t *testing.T) {
+	// NB: It's not clear that context cancellation is a good way to organize
+	// the duration of this (or any) test.
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Hour)
+	defer cancel()
+
+	localities := []string{
+		"us-east1", "us-east2", "us-west1",
+	}
+
+	var opts []roachprodng.Option
+	for _, loc := range localities {
+		opts = append(opts, roachprodng.GCE{Locality: loc})
+	}
+
+	c, err := roachprodng.Create(ctx, opts...)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// NB: this can be made a lot more ergonomical (pass options and a list of
+	// binaries, receive the file names plus a cleanup closure).
+	binaries := map[string]string{}
+	for _, binary := range []string{"cockroach", "workload"} {
+		binOpts := binfetcher.Options{
+			Binary:  binary,
+			Version: "LATEST",
+			GOOS:    "linux",
+			GOARCH:  "amd64",
+		}
+
+		loc, err := binfetcher.Download(ctx, binOpts)
+		if err != nil {
+			t.Fatal(errors.Wrap(err, binary))
+		}
+		defer func() {
+			_ = os.Remove(loc)
+		}()
+		binaries[binary] = loc
+	}
+
+	for dest, src := range binaries {
+		if err := c.Put(ctx, c.All(), src, dest); err != nil {
+			t.Fatal(errors.Wrap(err, src))
+		}
+	}
+
+	if err := c.Run(
+		ctx,
+		c.All(),
+		"./cockroach start --insecure --store {{Store 0}} --join {{Addr 0}}",
+		roachprodng.Detach(),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := c.Run(ctx, c.Node(0), "./cockroach init"); err != nil {
+		t.Fatal(err)
+	}
+
+	pgUrls := c.PGUrls(c.All(), 26257)
+
+	// Set up enterprise license and debug-friendly cluster settings.
+	// The information might have to come from env variables or flags.
+	if err := SetupTestingClusterSettings(pgUrls[0]); err != nil {
+		t.Fatal(err)
+	}
+
+	g, ctx := errgroup.WithContext(ctx)
+
+	g.Go(func() error {
+		return monitor.MakeSQLUptimeMonitor(monitor.Options{
+			Targets:        pgUrls,
+			CheckFrequency: 10 * time.Second,
+		}).Run(ctx)
+	})
+
+	c.Run(
+		ctx,
+		c.Node(0),
+		// NB: worth thinking about a way to handle creating (and caching) the
+		// fixtures on demand. The test may run a lot longer in that case, and
+		// the context-based cancellation would not work well (but we could just
+		// touch the fixtures early). Having to
+		// manually regenerate fixtures would suck.
+		"./workload fixtures load roachmart --localities 0,1,2 --scale 10",
+	)
+
+	for i := range localities {
+		i := i // copy for the goroutine
+		g.Go(func() error {
+			// NB: for long-running tests, better to run this detached and to
+			// use a monitor pattern (i.e. launch a process that terminates when
+			// it's done, and check in on it periodically).
+			//
+			// I'd prefer that as a default in general (you could run tests for
+			// weeks without worrying about the SSH session dropping, which is
+			// great for manual tests), but it's overkill for some tests.
+			//
+			// NB: decide how to print the output of these tests. Could try to
+			// use subtests instead of the errgroup (but we may generally want
+			// failfast all behavior).
+			return c.Run(
+				ctx,
+				c.Node(i),
+				"./workload run roachmart {{PGUrl 0 26257}} --locality ${{Locality}}",
+				roachprodng.V("Locality", i))
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Examples of some high-level tests that don't particularly care about setting
+// up the cluster themselves.
+//
+// NB: a nightly TeamCity job retrieves the list of top-level tests matching
+// `^(Test|Benchmark)Nightly` and spins up jobs for them, so adding to the code
+// below is all the work required.
+
+// TestNightlyWorkload spins up clusters for a variety of workloads and
+// benchmarks them (producing output similar to a Go benchmark).
+//
+// NB: Go benchmark functions are a poor fit here as we want to run all the
+// subtests in parallel.
+func TestNightlyWorkload(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Hour)
+	defer cancel()
+
+	for _, workload := range []struct {
+		name, cmd string
+	}{
+		{"kv_0", "kv --read-percent=0 --splits=1000 --concurrency=384 --duration=2h"},
+		{"kv_95", "kv --read-percent=95 --splits=1000 --concurrency=384 --duration=2h"},
+	} {
+
+		t.Run(workload.name, func(t *testing.T) {
+			// NB: it's unclear from the docs how much parallelism the test
+			// harness actually uses (but it's likely related to
+			// runtime.GOMAXPROCS?).
+			t.Parallel()
+
+			// RunPerf sets up a benchmarking cluster, sets up the fixture and
+			// runs the specified workload. It saves the output to the artifacts
+			// directory and perhaps sends the results somewhere (though perhaps
+			// this is a more appropriate task for the CI runner).
+			// It probably makes sense for it to append a subtest that gives a
+			// synopsis of the configuration (assuming we'll soon start running
+			// the same thing in multiple setups).
+			if err := RunNightlyPerf(ctx, workload.cmd, TestHelperOptions{
+				Nodes:   6, // cluster size
+				Runners: 3, // workload runners
+			}); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+// TestNightlyStress sets up a cluster and stresses it via a barrage of
+// diverse load generators and trouble makers.
+func TestNightlyStress(t *testing.T) {
+	const duration = 5 * time.Hour
+	ctx, cancel := context.WithTimeout(context.Background(), duration)
+	defer cancel()
+
+	// Set up a single cluster that gets hit by multiple non-overlapping workloads.
+	// Workloads are mapped to runners sequentially. If the list grows too large,
+	// we could run through the list in (randomized) waves.
+	c, err := SetupNightlyCluster(TestHelperOptions{
+		Nodes:      6,
+		Runners:    3,
+		Expiration: duration + time.Hour, // auto-destruction deadline
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Destroy()
+
+	for i, workload := range []struct {
+		name, cmd string
+	}{
+		// Scrubber looks up the existing schemas and runs SCRUB on each of them,
+		// until it is told to terminate.
+		{"scrubber", "scrubber"},
+		// The quintessential correctness test.
+		{"bank", "bank"},
+		// Some component that creates random schemas, runs random queries on
+		// that schema, adds and drops random indexes, ...
+		{"randomsyntax", "rsg"},
+		// Periodically looks up a random table and changes its zone configs.
+		{"randomrebalance", "rebalancer --frequency 15m"},
+		// Pick a random primary key and then focus all writers on it for 10min.
+		// Run three of these for more impact (they chose the primary key based
+		// on cluster time, so they will be highly correlated).
+		// NB: might be better as a targeted test.
+		{"hotspot", "hotspot --size 1mb --switch-after 10m"},
+		{"hotspot", "hotspot --size 1mb --switch-after 10m"},
+		{"hotspot", "hotspot --size 1mb --switch-after 10m"},
+	} {
+		i := i // probably have to take a copy because of t.Parallel()?
+		t.Run(workload.name, func(t *testing.T) {
+			t.Parallel()
+
+			// NB: should really create the fixtures first, i.e. add an init
+			// phase to this test. Note also that some workloads don't need
+			// a fixture, in which case that command should be a no-op (or
+			// create some empty DB/table).
+			c.Run(ctx, c.Node(0), "./workload fixtures load "+workload.cmd)
+
+			// NB: fileHelper creates a file in the artifacts directory.
+			f, err := fileHelper(t.Name())
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer f.Close()
+
+			if err := c.Run(
+				ctx, c.Node(i), "./workload run "+workload.cmd, roachprodng.CombinedOutput(f),
+			); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+
+	// Other ideas here: `dropflap`: imports some large table; drops it; repeat.
+	// (Don't quite want to model that one through `workload` but it's just a
+	// snippet of code taken from the verbose code at the top, using
+	// `workload.Fixtures()`).
+}
+
+// TestThatIsAlsoACLICommand illustrates what it would look like to have a
+// CLI-type workload that is called as a test. The workload gets a cluster of
+// any size and has to figure out what it wants to do. As a concrete example,
+// the impl of `roachperf test splits` would just assume that there's a running
+// cockroach cluster formed by all of the nodes and run splits via SQL. A perf
+// one could similarly launch a `workload kv run` on all of the nodes. Or
+// options could be passed in. Or a cli command could raze the existing cluster
+// and set up a new n-1 nodes cluster and one runner and then do whatever. The
+// API doesn't limit this in any way (and in particular *Cluster is fully
+// symmetric across all of its nodes -- it's pure hardware).
+func TestThatIsAlsoACLICommand(t *testing.T) {
+	c, err := SetupNightlyCluster(TestHelperOptions{
+		Nodes: 5,
+		Runners: 2,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := SomeCLITest(context.TODO(), c); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// A lot more things we may want to do. Run workloads and intentionally run
+// background load, with a pass/fail criterion on how badly the foreground load
+// is impacted. It's straightforward to write these given the building blocks
+// here.
+//
+// Run chaos. Corrupt disks. Disturb the network. All of these fit nicely enough
+// into the pattern but will need slightly different tooling, but at the end of
+// the day it won't be very different from what you've seen so far.
+

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -1,0 +1,26 @@
+package monitor
+
+import (
+	"context"
+	"time"
+)
+
+type Options struct {
+	Targets []string
+	CheckFrequency time.Duration
+}
+
+type Monitor struct {
+	opts Options
+}
+
+func MakeSQLUptimeMonitor(opts Options) *Monitor {
+	return &Monitor{
+		opts: opts,
+	}
+}
+
+func (m *Monitor) Run(ctx context.Context) error {
+	// TODO
+	return nil
+}

--- a/roachprodng/roachprod.go
+++ b/roachprodng/roachprod.go
@@ -1,0 +1,120 @@
+package roachprodng
+
+import (
+	"context"
+	"io"
+)
+
+type Cluster struct {
+	config struct {
+		gce []GCE
+	}
+}
+
+type Option interface {
+	apply(*Cluster)
+}
+
+type optionFn func(*Cluster)
+
+func (o optionFn) apply(c *Cluster) {
+	o(c)
+}
+
+func Create(ctx context.Context, opts ...Option) (*Cluster, error) {
+	var c Cluster
+	for _, opt := range opts {
+		opt.apply(&c)
+	}
+	// TODO: actually create
+	return &c, nil
+}
+
+type Nodes []int
+
+func (c *Cluster) Node(ns ...int) Nodes {
+	return Nodes(ns)
+}
+
+func (c *Cluster) All() Nodes {
+	// TODO
+	return nil
+}
+
+func (c *Cluster) Put(ctx context.Context, n Nodes, src, dest string) error {
+	// TODO
+	return nil
+}
+
+func (c *Cluster) Run(ctx context.Context, n Nodes, template string, opts ...RunOption) error {
+	// TODO
+	return nil
+}
+
+func (c *Cluster) Destroy() {
+	// TODO
+}
+
+func (c *Cluster) PGUrls(n Nodes, port int) []string {
+	// TODO
+	return nil
+}
+
+type RunOption interface {
+	apply(*runOptions)
+}
+
+type runOptions struct {
+	detach         bool
+	stdout, stderr io.WriteCloser
+	v map[string]interface{}
+}
+
+type detachOpt struct{}
+
+func Detach() detachOpt {
+	return detachOpt{}
+}
+
+func (detachOpt) apply(opts *runOptions) {
+	opts.detach = true
+}
+
+type combineOpt struct{
+	io.WriteCloser
+}
+
+func CombinedOutput(w io.WriteCloser) combineOpt {
+	return combineOpt{w}
+}
+
+func (opt combineOpt) apply(opts *runOptions) {
+	opts.stderr = opt
+	opts.stdout = opt
+}
+
+type vOpt struct{
+	k string
+	v interface{}
+}
+
+
+func V(k string, v interface{}) vOpt {
+	return vOpt{k,v}
+}
+
+func (opt vOpt) apply(opts *runOptions) {
+	if opts.v == nil {
+		opts.v = map[string]interface{}{}
+	}
+	opts.v[opt.k] = opt.v
+
+}
+
+type GCE struct {
+	Locality string
+}
+
+func (opt GCE) apply(c *Cluster) {
+	c.config.gce = append(c.config.gce, opt)
+}


### PR DESCRIPTION
This is an attempt to lay out a lower layer on which to build both
nightly tests (expanded upon in some detail here) and cli-driven
tools (i.e., mostly today's roachperf). This builds, but does not
work (most methods are stubs, but a lot of the required code already
exists in `roachprod/roachperf` and can be lifted).

These will naturally exist on various levels of abstraction. Some tests
may want to mount virtual file systems (to test corruption) and invoke
adversarial I/O workloads on the machines directly. Most performance
tests are much less concerned with these details and just need to be
told a number of Postgres endpoints and machines to run load generators
on.

Please take a look at this example code and provide criticism and
feedback. My impression is that this is a clean, elegant and at the
same time malleable foundation, and every test I have considered
wanting to write (there are a lot) seemed easy to string together
with these primitives.

The goal was to have a clear separation of concerns:

1. A *library* that provisions hardware (`roachprodng`, to be renamed
    when there's less confusion about names. I would probably just call this
    `provision` but there will be an opportunity to bikeshed).
    `roachprodng` does not know anything about CockroachDB.

    In the current code, this library exposes some details about the
    nodes (IP addresses, available mount points) and lets you SSH/scp into
    them, but not much else.

    As a convenience, `roachprodng` allows template interpolation to
    access the provisioned node state, which makes it natural to execute
    commands on the nodes. For example, `--store {{Store 0}}` expands to
    something like `--store /mnt/data0` where `/mnt/data0` could be a
    local SSD (if that's what `roachprodng` was told to set up). This
    avoids leaking provider-specific details into the tests and should
    make it relatively straightforward to target AWS later. (Aside from
    that, it also de-noises the tests and has been pleasant to work with).

2. The `binfetcher` library is used to procure binaries, which includes
`cockroach`, but also `workload`. Binaries can be put anywhere using
`roachprodng`.

3. SQL-specific operations usually rely on `cmd/workload`, which is
    invoked on the nodes to recreate and/or ingest fixtures, and serves as
    the general-purpose SQL runner, so that many tests will simply need a
    cluster and the information on where to invoke `workload`. (It's equally
    straightforward to create a manual SQL connection in a test when that
    is all that's desired: the endpoints are readily available).

4. Various other mechanisms are modular.

    For example, many tests will want to assert the continuous uptime of the
    cluster and can simply run a component that periodically verifies this
    (through SQL). Similarly, other tests may want to periodically run
    `SCRUB` (which can be done through `cmd/workload`).

    Yet another test may want to run chaos and can tap into a modular
    component that fits in easily, though they now have to make sure that
    the load they're running tolerates errors better, and they need to
    make the monitoring component aware of the chaos events.

Note that the nightly benchmark tests are intentionally a bit
simplistic.  We'll likely want to tap into the existing `testRun` struct
from `roachperf`. This is intentional to keep the noise level down; some
of that integration is likely to happen inside of `cmd/workload` anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/27)
<!-- Reviewable:end -->
