### PR TITLE
Add "monitor" command

### DIFF
--- a/cluster_synced.go
+++ b/cluster_synced.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"log"
@@ -174,6 +175,77 @@ fi
 	for i, r := range results {
 		fmt.Printf("  %2d: %s\n", c.nodes[i], r)
 	}
+}
+
+type nodeMonitorInfo struct {
+	index int
+	msg   string
+}
+
+func (c *syncedCluster) monitor() chan nodeMonitorInfo {
+	ch := make(chan nodeMonitorInfo)
+	nodes := c.serverNodes()
+
+	for i := range nodes {
+		go func(i int) {
+			session, err := newSSHSession(c.user(nodes[i]), c.host(nodes[i]))
+			if err != nil {
+				ch <- nodeMonitorInfo{nodes[i], err.Error()}
+				return
+			}
+			defer session.Close()
+
+			go func() {
+				p, err := session.StdoutPipe()
+				if err != nil {
+					ch <- nodeMonitorInfo{nodes[i], err.Error()}
+					return
+				}
+				r := bufio.NewReader(p)
+				for {
+					line, _, err := r.ReadLine()
+					if err == io.EOF {
+						return
+					}
+					ch <- nodeMonitorInfo{nodes[i], string(line)}
+				}
+			}()
+
+			// On each monitored node, we loop looking for a cockroach process. In
+			// order to avoid polling with lsof, if we find a live process we use nc
+			// (netcat) to connect to the rpc port which will block until the server
+			// either decides to kill the connection or the process is killed.
+			cmd := fmt.Sprintf(`
+lastpid=0
+while :; do
+  pid=$(lsof -i :%[1]d -sTCP:LISTEN | awk '!/COMMAND/ {print $2}')
+  if [ "${pid}" != "${lastpid}" ]; then
+    if [ -n "${lastpid}" -a -z "${pid}" ]; then
+      echo dead
+    fi
+    lastpid=${pid}
+    if [ -n "${pid}" ]; then
+      echo ${pid}
+    fi
+  fi
+
+  if [ -n "${lastpid}" ]; then
+    nc localhost %[1]d >/dev/null 2>&1
+  else
+    sleep 1
+  fi
+done
+`,
+				cockroach{}.nodePort(c, nodes[i]))
+
+			if err := session.Run(cmd); err != nil {
+				ch <- nodeMonitorInfo{nodes[i], err.Error()}
+				return
+			}
+		}(i)
+	}
+
+	return ch
 }
 
 func (c *syncedCluster) run(w io.Writer, nodes []int, title, cmd string) error {

--- a/main.go
+++ b/main.go
@@ -513,6 +513,23 @@ var statusCmd = &cobra.Command{
 	},
 }
 
+var monitorCmd = &cobra.Command{
+	Use:   "monitor",
+	Short: "monitor the status of a cluster",
+	Long:  `Continuously monitor the status of a cluster.`,
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c, err := newCluster(args[0], false /* reserveLoadGen */)
+		if err != nil {
+			return err
+		}
+		for i := range c.monitor() {
+			fmt.Printf("%d: %s\n", i.index, i.msg)
+		}
+		return nil
+	},
+}
+
 var wipeCmd = &cobra.Command{
 	Use:   "wipe <cluster>",
 	Short: "wipe a cluster",
@@ -726,8 +743,8 @@ func main() {
 	cobra.EnableCommandSorting = false
 
 	rootCmd.AddCommand(createCmd, destroyCmd, extendCmd, listCmd, syncCmd, gcCmd,
-		statusCmd, startCmd, stopCmd, runCmd, wipeCmd, testCmd, workloadTestCmd, installCmd, putCmd,
-		getCmd, sshCmd, pgurlCmd, uploadCmd, webCmd, dumpCmd)
+		statusCmd, monitorCmd, startCmd, stopCmd, runCmd, wipeCmd, testCmd, workloadTestCmd,
+		installCmd, putCmd, getCmd, sshCmd, pgurlCmd, uploadCmd, webCmd, dumpCmd)
 	rootCmd.Flags().BoolVar(
 		&insecureIgnoreHostKey, "insecure-ignore-host-key", true, "don't check ssh host keys")
 


### PR DESCRIPTION
The "monitor" command continuously monitors the nodes in the cluster,
outputting a line at startup for each node in the cluster and whenever
the status of a node changes. For example, the following shows the
output from `roachprod monitor` on a 4 node cluster which started off
with all of the nodes down, the cluster was brought up and then node 3
was stopped and restarted:

```
4: dead
3: dead
1: dead
2: dead
4: 16141
3: 12590
2: 6340
1: 5707
3: dead
3: 14280
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/34)
<!-- Reviewable:end -->
