### PR TITLE
Add "ssh" command

### DIFF
--- a/cluster_synced.go
+++ b/cluster_synced.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"math"
 	"os"
+	"os/exec"
 	"os/signal"
 	"sort"
 	"strings"
@@ -456,6 +457,24 @@ func (c *syncedCluster) get(src, dest string) {
 	if haveErr {
 		log.Fatal("failed")
 	}
+}
+
+func (c *syncedCluster) ssh(args []string) error {
+	if len(c.nodes) != 1 {
+		return fmt.Errorf("invalid number of nodes for ssh: %d", c.nodes)
+	}
+
+	allArgs := []string{fmt.Sprintf("%s@%s", c.user(c.nodes[0]), c.host(c.nodes[0]))}
+	allArgs = append(allArgs, args...)
+
+	cmd := exec.Command(`ssh`, allArgs...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v", err)
+	}
+	return nil
 }
 
 func (c *syncedCluster) stopLoad() {

--- a/main.go
+++ b/main.go
@@ -648,6 +648,20 @@ multiple nodes the destination file name will be prefixed with the node number.`
 	},
 }
 
+var sshCmd = &cobra.Command{
+	Use:   "ssh <cluster> [args]",
+	Short: "ssh to a node on a remote cluster",
+	Long:  `Ssh to a node on a remote cluster.`,
+	Args:  cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c, err := newCluster(args[0], false /* reserveLoadGen */)
+		if err != nil {
+			return err
+		}
+		return c.ssh(args[1:])
+	},
+}
+
 var pgurlCmd = &cobra.Command{
 	Use:   "pgurl <cluster>",
 	Short: "generate pgurls for the nodes in a cluster\n",
@@ -713,7 +727,7 @@ func main() {
 
 	rootCmd.AddCommand(createCmd, destroyCmd, extendCmd, listCmd, syncCmd, gcCmd,
 		statusCmd, startCmd, stopCmd, runCmd, wipeCmd, testCmd, workloadTestCmd, installCmd, putCmd,
-		getCmd, pgurlCmd, uploadCmd, webCmd, dumpCmd)
+		getCmd, sshCmd, pgurlCmd, uploadCmd, webCmd, dumpCmd)
 	rootCmd.Flags().BoolVar(
 		&insecureIgnoreHostKey, "insecure-ignore-host-key", true, "don't check ssh host keys")
 


### PR DESCRIPTION
This gets rid of the need for `crl-ssh` which was one of the last
`crl-*` commands I use.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/37)
<!-- Reviewable:end -->
