### PR TITLE
Allow template expansion for arguments to the "ssh" command

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,13 +41,17 @@ var (
 	clusters       = map[string]*syncedCluster{}
 )
 
+func allNodes(total int) []int {
+	r := make([]int, total)
+	for i := range r {
+		r[i] = i + 1
+	}
+	return r
+}
+
 func listNodes(s string, total int) ([]int, error) {
 	if s == "all" {
-		r := make([]int, total)
-		for i := range r {
-			r[i] = i + 1
-		}
-		return r, nil
+		return allNodes(total), nil
 	}
 
 	m := map[int]bool{}
@@ -197,9 +201,9 @@ Hint: use "roachprod sync" to update the list of available clusters.
 			}
 		}
 
-		c.vms = make([]string, max+1)
-		c.users = make([]string, max+1)
-		c.localities = make([]string, max+1)
+		c.vms = make([]string, max)
+		c.users = make([]string, max)
+		c.localities = make([]string, max)
 		for i := range c.vms {
 			c.vms[i] = "localhost"
 			c.users[i] = osUser.Username
@@ -701,7 +705,7 @@ var pgurlCmd = &cobra.Command{
 
 		var urls []string
 		for i, ip := range ips {
-			urls = append(urls, c.impl.nodeURL(c, ip, c.impl.nodePort(c, c.nodes[i])))
+			urls = append(urls, c.impl.nodeURL(c, ip, c.impl.nodePort(c, nodes[i])))
 		}
 		fmt.Println(strings.Join(urls, " "))
 		return nil
@@ -770,6 +774,9 @@ func main() {
 	gcCmd.Flags().StringVar(&gcEmailOpts.Password, "email-password", "", "SMTP password")
 	gcCmd.Flags().DurationVar(&destroyAfter, "destroy-after", 6*time.Hour, "Destroy when this much time past expiration")
 	gcCmd.Flags().StringVar(&trackingFile, "tracking-file", "roachprod.tracking.txt", "Tracking file to avoid duplicate emails")
+
+	sshCmd.Flags().BoolVar(
+		&secure, "secure", false, "use a secure cluster")
 
 	startCmd.Flags().StringVarP(
 		&binary, "binary", "b", "./cockroach", "the remote cockroach binary used to start a server")


### PR DESCRIPTION
Currently the only expansion supported is `{pgurl:<nodes>}`. If
`<nodes>` is not specified, `{pgurl}` expands to the pgurls for all of
the nodes in the cluster. The expansions allow `ssh` to be used for
starting a load generator. For example:

```
  roachprod ssh peter-perf:4 ./kv {pgurl:1-3}
```

If `peter-perf` is a 3 node cluster, this expands to:

```
  ./kv postgres://root@10.142.0.4:26257?sslmode=disable \
       postgres://root@10.142.0.3:26257?sslmode=disable \
       postgres://root@10.142.0.2:26257?sslmode=disable
```

Added the `--secure` flag to the `ssh` command which affects the
expansion of `pgurl`. Might be desirable in the future to automatically
infer from the cluster itself whether it is secure or not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/38)
<!-- Reviewable:end -->
