### PR TITLE
Optionally start nodes sequentially

### DIFF
--- a/cockroach.go
+++ b/cockroach.go
@@ -5,13 +5,22 @@ import (
 	"strings"
 )
 
+var startOpts struct {
+	sequential bool
+}
+
 type cockroach struct{}
 
 func (r cockroach) start(c *syncedCluster) {
 	display := fmt.Sprintf("%s: starting", c.name)
 	host1 := c.host(1)
 	nodes := c.serverNodes()
-	c.parallel(display, len(nodes), 0, func(i int) ([]byte, error) {
+
+	p := 0
+	if startOpts.sequential {
+		p = 1
+	}
+	c.parallel(display, len(nodes), p, func(i int) ([]byte, error) {
 		host := c.host(nodes[i])
 		user := c.user(nodes[i])
 		session, err := newSSHSession(user, host)

--- a/main.go
+++ b/main.go
@@ -793,6 +793,8 @@ func main() {
 
 	startCmd.Flags().StringVarP(
 		&binary, "binary", "b", "./cockroach", "the remote cockroach binary used to start a server")
+	startCmd.Flags().BoolVar(
+		&startOpts.sequential, "sequential", false, "start nodes sequentially so node IDs match hostnames")
 
 	testCmd.Flags().StringVarP(
 		&binary, "binary", "b", "./cockroach", "the remote cockroach binary used to start a server")


### PR DESCRIPTION
Provide a flag that starts nodes sequentially so that node IDs match
hostnames.

Fix #47.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/48)
<!-- Reviewable:end -->
