### PR TITLE
Add missing newline to error message

### DIFF
--- a/main.go
+++ b/main.go
@@ -865,7 +865,7 @@ will perform %[1]s on:
 	var err error
 	osUser, err = user.Current()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "unable to lookup current user: %s", err)
+		fmt.Fprintf(os.Stderr, "unable to lookup current user: %s\n", err)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
Of course I notice this 2 seconds after merging the previous commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/55)
<!-- Reviewable:end -->
