### PR TITLE
Exec ssh instead of fork/exec

### DIFF
--- a/cluster_synced.go
+++ b/cluster_synced.go
@@ -640,6 +640,7 @@ func (c *syncedCluster) ssh(args []string) error {
 	}
 
 	allArgs := []string{
+		"ssh",
 		fmt.Sprintf("%s@%s", c.user(c.nodes[0]), c.host(c.nodes[0])),
 		"-i", filepath.Join(osUser.HomeDir, ".ssh", "google_compute_engine"),
 		"-o", "StrictHostKeyChecking=no",
@@ -682,11 +683,11 @@ func (c *syncedCluster) ssh(args []string) error {
 		allArgs = append(allArgs, strings.Split(arg, " ")...)
 	}
 
-	cmd := exec.Command(`ssh`, allArgs...)
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	sshPath, err := exec.LookPath(allArgs[0])
+	if err != nil {
+		return err
+	}
+	return syscall.Exec(sshPath, allArgs, os.Environ())
 }
 
 func (c *syncedCluster) stopLoad() {

--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"os/signal"
 	"os/user"
 	"path"
 	"path/filepath"
@@ -848,19 +847,6 @@ will perform %[1]s on:
     marc-test-9
 `, cmd.Name())
 	}
-
-	// Forward SIGTERM to any child processes that get created.
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, unix.SIGTERM)
-	if err := unix.Setpgid(0, 0); err != nil {
-		fmt.Fprintf(os.Stderr, "%v", err)
-		os.Exit(1)
-	}
-	go func() {
-		<-sigCh
-		signal.Reset(unix.SIGTERM)
-		unix.Kill(-os.Getpid(), unix.SIGTERM)
-	}()
 
 	var err error
 	osUser, err = user.Current()


### PR DESCRIPTION
Exec ssh instead of fork/exec so that the roachprod process is replace
by the ssh process. This allows the caller of `roachprod ssh` to kill
`roachprod` with `kill -9` and not worry about leaving the `ssh` process
around.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/56)
<!-- Reviewable:end -->
