### PR TITLE
Add support for creating and destroying "local" clusters

### DIFF
--- a/cluster_cloud.go
+++ b/cluster_cloud.go
@@ -1,12 +1,16 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"log"
+	"os"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
 	"sync"
+	"text/tabwriter"
 	"time"
 
 	"github.com/pkg/errors"
@@ -52,20 +56,33 @@ func (c *CloudCluster) LifetimeRemaining() time.Duration {
 }
 
 func (c *CloudCluster) String() string {
-	return fmt.Sprintf("%s: %d (%s)", c.Name, len(c.VMs), c.LifetimeRemaining().Round(time.Second))
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "%s: %d", c.Name, len(c.VMs))
+	if !c.isLocal() {
+		fmt.Fprintf(&buf, " (%s)", c.LifetimeRemaining().Round(time.Second))
+	}
+	return buf.String()
 }
 
 func (c *CloudCluster) PrintDetails() {
 	fmt.Printf("%s: ", c.Name)
-	l := c.LifetimeRemaining().Round(time.Second)
-	if l <= 0 {
-		fmt.Printf("expired %s ago\n", -l)
+	if !c.isLocal() {
+		l := c.LifetimeRemaining().Round(time.Second)
+		if l <= 0 {
+			fmt.Printf("expired %s ago\n", -l)
+		} else {
+			fmt.Printf("%s remaining\n", l)
+		}
 	} else {
-		fmt.Printf("%s remaining\n", l)
+		fmt.Printf("(no expiration)\n")
 	}
 	for _, vm := range c.VMs {
-		fmt.Printf("  %s\t%s.%s.%s\t%s\t%s\n", vm.Name, vm.Name, vm.Zone, project, vm.PrivateIP, vm.PublicIP)
+		fmt.Printf("  %s\t%s\t%s\t%s\n", vm.Name, vm.dns(), vm.PrivateIP, vm.PublicIP)
 	}
+}
+
+func (c *CloudCluster) isLocal() bool {
+	return c.Name == local
 }
 
 type VM struct {
@@ -81,12 +98,21 @@ var regionRE = regexp.MustCompile(`(.*[^-])-?[a-z]$`)
 
 func (vm *VM) locality() string {
 	var region string
-	if match := regionRE.FindStringSubmatch(vm.Zone); len(match) == 2 {
+	if vm.Zone == local {
+		region = local
+	} else if match := regionRE.FindStringSubmatch(vm.Zone); len(match) == 2 {
 		region = match[1]
 	} else {
 		log.Fatalf("unable to parse region from zone %q", vm.Zone)
 	}
 	return fmt.Sprintf("region=%s,zone=%s", region, vm.Zone)
+}
+
+func (vm *VM) dns() string {
+	if vm.Zone == local {
+		return vm.Name
+	}
+	return fmt.Sprintf("%s.%s.%s", vm.Name, vm.Zone, project)
 }
 
 type VMList []VM
@@ -155,7 +181,7 @@ func listCloud() (*Cloud, error) {
 				User:      userName,
 				CreatedAt: createdAt,
 				Lifetime:  lifetime,
-				VMs:       make([]VM, 0),
+				VMs:       nil,
 			}
 		}
 
@@ -176,6 +202,28 @@ func listCloud() (*Cloud, error) {
 		}
 	}
 
+	// Initialize the local cluster (if it exists)
+	if sc, ok := clusters[local]; ok {
+		c := &CloudCluster{
+			Name:      local,
+			User:      osUser.Username,
+			CreatedAt: time.Now(),
+			Lifetime:  time.Hour,
+		}
+		cloud.Clusters[local] = c
+
+		for range sc.vms {
+			c.VMs = append(c.VMs, VM{
+				Name:      "localhost",
+				CreatedAt: c.CreatedAt,
+				Lifetime:  time.Hour,
+				PrivateIP: "127.0.0.1",
+				PublicIP:  "127.0.0.1",
+				Zone:      local,
+			})
+		}
+	}
+
 	// Sort VMs for each cluster. We want to make sure we always have the same order.
 	for _, c := range cloud.Clusters {
 		sort.Sort(c.VMs)
@@ -183,7 +231,32 @@ func listCloud() (*Cloud, error) {
 	return cloud, nil
 }
 
+func createLocalCluster(name string, nodes int) error {
+	path := filepath.Join(os.ExpandEnv(defaultHostDir), name)
+	file, err := os.Create(path)
+	if err != nil {
+		return errors.Wrapf(err, "problem creating file %s", path)
+	}
+	defer file.Close()
+
+	// Align columns left and separate with at least two spaces.
+	tw := tabwriter.NewWriter(file, 0, 8, 2, ' ', 0)
+	tw.Write([]byte("# user@host\tlocality\n"))
+	for i := 0; i < nodes; i++ {
+		tw.Write([]byte(fmt.Sprintf(
+			"%s@%s\t%s\n", osUser.Username, "127.0.0.1", "region=local,zone=local")))
+	}
+	if err := tw.Flush(); err != nil {
+		return errors.Wrapf(err, "problem writing file %s", path)
+	}
+	return nil
+}
+
 func createCluster(name string, nodes int, opts VMOpts) error {
+	if name == local {
+		return createLocalCluster(name, nodes)
+	}
+
 	vmNames := make([]string, nodes, nodes)
 	for i := 0; i < nodes; i++ {
 		// Start instance indexing at 1.
@@ -194,6 +267,15 @@ func createCluster(name string, nodes int, opts VMOpts) error {
 }
 
 func destroyCluster(c *CloudCluster) error {
+	if c.isLocal() {
+		t, err := newCluster(c.Name, false /* reserveLoadGen */)
+		if err != nil {
+			return err
+		}
+		t.wipe()
+		return os.Remove(filepath.Join(os.ExpandEnv(defaultHostDir), c.Name))
+	}
+
 	n := len(c.VMs)
 	vmNames := make([]string, n, n)
 	vmZones := make([]string, n, n)
@@ -206,6 +288,10 @@ func destroyCluster(c *CloudCluster) error {
 }
 
 func extendCluster(c *CloudCluster, extension time.Duration) error {
+	if c.isLocal() {
+		return errors.New("local clusters have unlimited lifetime")
+	}
+
 	newLifetime := c.Lifetime + extension
 	extendErrors := make([]error, len(c.VMs))
 	var wg sync.WaitGroup

--- a/hosts.go
+++ b/hosts.go
@@ -34,6 +34,7 @@ func syncHosts(cloud *Cloud) error {
 		if err != nil {
 			return errors.Wrapf(err, "problem creating file %s", filename)
 		}
+		defer file.Close()
 
 		// Align columns left and separate with at least two spaces.
 		tw := tabwriter.NewWriter(file, 0, 8, 2, ' ', 0)
@@ -137,8 +138,5 @@ func loadClusters() error {
 		clusters[file.Name()] = c
 	}
 
-	clusters[local] = &syncedCluster{
-		name: local,
-	}
 	return nil
 }


### PR DESCRIPTION
Local clusters are now no longer created on demand by `start` and
`status`, but instead must exist in the `~/.roachprod/hosts` directory
like other clusters. Usage is similar to a cloud cluster:

```
  roachprod create local -n 5
  roachprod start local
  roachprod stop local
  roachprod destroy local
```

Note that `roachprod destroy local` will also stop any local cockroach
nodes that are running and wipe the local state in `~/local`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/57)
<!-- Reviewable:end -->
