### PR TITLE
Avoid using gcloud when manipulating local clusters

### DIFF
--- a/cluster_cloud.go
+++ b/cluster_cloud.go
@@ -268,12 +268,8 @@ func createCluster(name string, nodes int, opts VMOpts) error {
 
 func destroyCluster(c *CloudCluster) error {
 	if c.isLocal() {
-		t, err := newCluster(c.Name, false /* reserveLoadGen */)
-		if err != nil {
-			return err
-		}
-		t.wipe()
-		return os.Remove(filepath.Join(os.ExpandEnv(defaultHostDir), c.Name))
+		// Local cluster destruction is handled in destroyCmd.
+		return errors.New("local clusters cannot be destroyed")
 	}
 
 	n := len(c.VMs)

--- a/cluster_synced.go
+++ b/cluster_synced.go
@@ -131,7 +131,7 @@ func (c *syncedCluster) wipe() {
 			cockroach{}.nodePort(c, c.nodes[i]),
 			cassandra{}.nodePort(c, c.nodes[i]))
 		if c.isLocal() {
-			cmd += `rm -fr ${HOME}/local ;`
+			cmd += fmt.Sprintf(`rm -fr ${HOME}/local/cockroach%d ;`, c.nodes[i])
 		} else {
 			cmd += `find /mnt/data* -maxdepth 1 -type f -exec rm -f {} \; ;
 rm -fr /mnt/data*/{auxiliary,local,tmp,cassandra,cockroach,cockroach-temp*,mongo-data} \; ;


### PR DESCRIPTION
This speeds up local cluster creation and destruction by about an order
of magnitude due to not having to list the cloud clusters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/58)
<!-- Reviewable:end -->
