### PR TITLE
generate bash completions

### DIFF
--- a/main.go
+++ b/main.go
@@ -409,6 +409,8 @@ var syncCmd = &cobra.Command{
 
 var lockFile = os.ExpandEnv("$HOME/.roachprod/LOCK")
 
+var bashCompletion = os.ExpandEnv("$HOME/.roachprod/bash-completion.sh")
+
 func syncAll(cloud *Cloud) error {
 	fmt.Println("Syncing...")
 
@@ -428,6 +430,19 @@ func syncAll(cloud *Cloud) error {
 	}
 	if err := cleanSSH(); err != nil {
 		return err
+	}
+
+	{
+		names := make([]string, 0, len(cloud.Clusters))
+		for name := range cloud.Clusters {
+			names = append(names, name)
+		}
+		for _, cmd := range []*cobra.Command{
+			destroyCmd, statusCmd, monitorCmd, startCmd, stopCmd, wipeCmd, sshCmd,
+		} {
+			cmd.ValidArgs = names
+		}
+		rootCmd.GenBashCompletionFile(bashCompletion)
 	}
 	return configSSH()
 }


### PR DESCRIPTION
Re-generate bash completions on sync, after adding the synced cluster names to the cobra arg structs.

Note: since the cluster names are inlined in the completion func, it needs to be re-sourced after sync to pick up changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/59)
<!-- Reviewable:end -->
