### PR TITLE
Reorganize roachprod code into packages

### DIFF
--- a/cloud/cluster_cloud.go
+++ b/cloud/cluster_cloud.go
@@ -1,4 +1,4 @@
-package main
+package cloud
 
 import (
 	"bytes"
@@ -7,12 +7,12 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"sort"
 	"strings"
 	"sync"
 	"text/tabwriter"
 	"time"
 
+	"github.com/cockroachdb/roachprod/config"
 	"github.com/pkg/errors"
 )
 
@@ -58,7 +58,7 @@ func (c *CloudCluster) LifetimeRemaining() time.Duration {
 func (c *CloudCluster) String() string {
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "%s: %d", c.Name, len(c.VMs))
-	if !c.isLocal() {
+	if !c.IsLocal() {
 		fmt.Fprintf(&buf, " (%s)", c.LifetimeRemaining().Round(time.Second))
 	}
 	return buf.String()
@@ -66,7 +66,7 @@ func (c *CloudCluster) String() string {
 
 func (c *CloudCluster) PrintDetails() {
 	fmt.Printf("%s: ", c.Name)
-	if !c.isLocal() {
+	if !c.IsLocal() {
 		l := c.LifetimeRemaining().Round(time.Second)
 		if l <= 0 {
 			fmt.Printf("expired %s ago\n", -l)
@@ -81,8 +81,8 @@ func (c *CloudCluster) PrintDetails() {
 	}
 }
 
-func (c *CloudCluster) isLocal() bool {
-	return c.Name == local
+func (c *CloudCluster) IsLocal() bool {
+	return c.Name == config.Local
 }
 
 type VM struct {
@@ -96,10 +96,10 @@ type VM struct {
 
 var regionRE = regexp.MustCompile(`(.*[^-])-?[a-z]$`)
 
-func (vm *VM) locality() string {
+func (vm *VM) Locality() string {
 	var region string
-	if vm.Zone == local {
-		region = local
+	if vm.Zone == config.Local {
+		region = config.Local
 	} else if match := regionRE.FindStringSubmatch(vm.Zone); len(match) == 2 {
 		region = match[1]
 	} else {
@@ -109,7 +109,7 @@ func (vm *VM) locality() string {
 }
 
 func (vm *VM) dns() string {
-	if vm.Zone == local {
+	if vm.Zone == config.Local {
 		return vm.Name
 	}
 	return fmt.Sprintf("%s.%s.%s", vm.Name, vm.Zone, project)
@@ -129,7 +129,9 @@ func namesFromVMName(name string) (string, string, error) {
 	return parts[0], strings.Join(parts[:len(parts)-1], "-"), nil
 }
 
-func listCloud() (*Cloud, error) {
+// Note that this **does not** initialize the local CloudCluster object unlike the
+// original version.  That local-initialization behavior currently resides in main.go.
+func ListCloud() (*Cloud, error) {
 	vms, err := listVMs()
 	if err != nil {
 		return nil, err
@@ -202,37 +204,11 @@ func listCloud() (*Cloud, error) {
 		}
 	}
 
-	// Initialize the local cluster (if it exists)
-	if sc, ok := clusters[local]; ok {
-		c := &CloudCluster{
-			Name:      local,
-			User:      osUser.Username,
-			CreatedAt: time.Now(),
-			Lifetime:  time.Hour,
-		}
-		cloud.Clusters[local] = c
-
-		for range sc.vms {
-			c.VMs = append(c.VMs, VM{
-				Name:      "localhost",
-				CreatedAt: c.CreatedAt,
-				Lifetime:  time.Hour,
-				PrivateIP: "127.0.0.1",
-				PublicIP:  "127.0.0.1",
-				Zone:      local,
-			})
-		}
-	}
-
-	// Sort VMs for each cluster. We want to make sure we always have the same order.
-	for _, c := range cloud.Clusters {
-		sort.Sort(c.VMs)
-	}
 	return cloud, nil
 }
 
 func createLocalCluster(name string, nodes int) error {
-	path := filepath.Join(os.ExpandEnv(defaultHostDir), name)
+	path := filepath.Join(os.ExpandEnv(config.DefaultHostDir), name)
 	file, err := os.Create(path)
 	if err != nil {
 		return errors.Wrapf(err, "problem creating file %s", path)
@@ -244,7 +220,7 @@ func createLocalCluster(name string, nodes int) error {
 	tw.Write([]byte("# user@host\tlocality\n"))
 	for i := 0; i < nodes; i++ {
 		tw.Write([]byte(fmt.Sprintf(
-			"%s@%s\t%s\n", osUser.Username, "127.0.0.1", "region=local,zone=local")))
+			"%s@%s\t%s\n", config.OSUser.Username, "127.0.0.1", "region=local,zone=local")))
 	}
 	if err := tw.Flush(); err != nil {
 		return errors.Wrapf(err, "problem writing file %s", path)
@@ -252,8 +228,8 @@ func createLocalCluster(name string, nodes int) error {
 	return nil
 }
 
-func createCluster(name string, nodes int, opts VMOpts) error {
-	if name == local {
+func CreateCluster(name string, nodes int, opts VMOpts) error {
+	if name == config.Local {
 		return createLocalCluster(name, nodes)
 	}
 
@@ -266,8 +242,8 @@ func createCluster(name string, nodes int, opts VMOpts) error {
 	return createVMs(vmNames, opts)
 }
 
-func destroyCluster(c *CloudCluster) error {
-	if c.isLocal() {
+func DestroyCluster(c *CloudCluster) error {
+	if c.IsLocal() {
 		// Local cluster destruction is handled in destroyCmd.
 		return errors.New("local clusters cannot be destroyed")
 	}
@@ -283,8 +259,8 @@ func destroyCluster(c *CloudCluster) error {
 	return deleteVMs(vmNames, vmZones)
 }
 
-func extendCluster(c *CloudCluster, extension time.Duration) error {
-	if c.isLocal() {
+func ExtendCluster(c *CloudCluster, extension time.Duration) error {
+	if c.IsLocal() {
 		return errors.New("local clusters have unlimited lifetime")
 	}
 

--- a/cloud/gc.go
+++ b/cloud/gc.go
@@ -1,4 +1,4 @@
-package main
+package cloud
 
 import (
 	"bytes"
@@ -9,20 +9,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cockroachdb/roachprod/config"
 	"github.com/pkg/errors"
 	gomail "gopkg.in/gomail.v2"
 )
-
-// EmailOpts is the set of options needed to configure the email client.
-type EmailOpts struct {
-	From     string
-	Host     string
-	Port     int
-	User     string
-	Password string
-}
-
-var gcEmailOpts EmailOpts
 
 // Tracks all the clusters to notify a user about.
 type userNotification struct {
@@ -33,10 +23,10 @@ type userNotification struct {
 	BadVMs   []string
 }
 
-// gcClusters checks all cluster to see if they should be deleted. It only
+// GCClusters checks all cluster to see if they should be deleted. It only
 // fails on failure to perform cloud actions. All others actions (load/save
 // file, email) do not abort.
-func gcClusters(cloud *Cloud, filename string, destroyAfter time.Duration) error {
+func GCClusters(cloud *Cloud, filename string, destroyAfter time.Duration) error {
 	trackedClusters := loadTrackingFile(filename)
 
 	now := time.Now()
@@ -90,7 +80,7 @@ func gcClusters(cloud *Cloud, filename string, destroyAfter time.Duration) error
 		needEmail := len(act.Destroy) > 0
 		// Destroy marked clusters.
 		for _, c := range act.Destroy {
-			if err := destroyCluster(c); err != nil {
+			if err := DestroyCluster(c); err != nil {
 				return errors.Wrapf(err, "failed to destroy cluster %s", c.Name)
 			}
 		}
@@ -238,7 +228,7 @@ func buildEmail(actions *userNotification) *gomail.Message {
 	}
 
 	m := gomail.NewMessage()
-	m.SetHeader("From", gcEmailOpts.From)
+	m.SetHeader("From", config.GCEmailOpts.From)
 	m.SetHeader("To", fmt.Sprintf("%s%s", actions.Username, domain))
 	m.SetHeader("Subject", time.Now().Format("Roachprod clusters 2006-01-02"))
 	m.SetBody("text/html", buf.String())
@@ -247,18 +237,18 @@ func buildEmail(actions *userNotification) *gomail.Message {
 }
 
 func sendEmails(emails []*gomail.Message) {
-	if len(gcEmailOpts.From) == 0 ||
-		len(gcEmailOpts.Host) == 0 ||
-		gcEmailOpts.Port == 0 ||
-		len(gcEmailOpts.User) == 0 ||
-		len(gcEmailOpts.Password) == 0 {
+	if len(config.GCEmailOpts.From) == 0 ||
+		len(config.GCEmailOpts.Host) == 0 ||
+		config.GCEmailOpts.Port == 0 ||
+		len(config.GCEmailOpts.User) == 0 ||
+		len(config.GCEmailOpts.Password) == 0 {
 		log.Printf("you must specify all --email options to send email")
 		return
 	}
 
 	dialer := gomail.NewDialer(
-		gcEmailOpts.Host, gcEmailOpts.Port,
-		gcEmailOpts.User, gcEmailOpts.Password)
+		config.GCEmailOpts.Host, config.GCEmailOpts.Port,
+		config.GCEmailOpts.User, config.GCEmailOpts.Password)
 
 	sender, err := dialer.Dial()
 	if err != nil {

--- a/cloud/utils.go
+++ b/cloud/utils.go
@@ -1,4 +1,4 @@
-package main
+package cloud
 
 import (
 	"io/ioutil"
@@ -51,7 +51,7 @@ func writeStartupScript() (string, error) {
 	return tmpfile.Name(), nil
 }
 
-func versionSatifies(v *version.Version, constraintString string) bool {
+func VersionSatifies(v *version.Version, constraintString string) bool {
 	constraints, err := version.NewConstraint(constraintString)
 	if err != nil {
 		panic(err)

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,38 @@
+package config
+
+import (
+	"log"
+	"os/user"
+)
+
+var (
+	Binary      = "./cockroach"
+	GCEmailOpts EmailOpts
+	OSUser      *user.User
+	Zones       []string
+)
+
+func init() {
+	var err error
+	OSUser, err = user.Current()
+	if err != nil {
+		log.Panic("Unable to determine OS user", err)
+	}
+}
+
+// EmailOpts is the set of options needed to configure the email client.
+type EmailOpts struct {
+	From     string
+	Host     string
+	Port     int
+	User     string
+	Password string
+}
+
+// A sentinel value used to indicate that an installation should
+// take place on the local machine.  Later in the refactoring,
+// this ought to be replaced by a LocalCloudProvider or somesuch.
+const (
+	Local          = "local"
+	DefaultHostDir = "${HOME}/.roachprod/hosts"
+)

--- a/hosts.go
+++ b/hosts.go
@@ -10,22 +10,23 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/cockroachdb/roachprod/cloud"
+	"github.com/cockroachdb/roachprod/config"
+	"github.com/cockroachdb/roachprod/install"
 	"github.com/pkg/errors"
 )
 
 const (
-	defaultHostDir   = "${HOME}/.roachprod/hosts"
-	local            = "local"
 	sshKeyPathPrefix = "${HOME}/.ssh/roachprod"
 )
 
 func initHostDir() error {
-	hd := os.ExpandEnv(defaultHostDir)
+	hd := os.ExpandEnv(config.DefaultHostDir)
 	return os.MkdirAll(hd, 0755)
 }
 
-func syncHosts(cloud *Cloud) error {
-	hd := os.ExpandEnv(defaultHostDir)
+func syncHosts(cloud *cloud.Cloud) error {
+	hd := os.ExpandEnv(config.DefaultHostDir)
 
 	// Write all host files.
 	for _, c := range cloud.Clusters {
@@ -43,7 +44,7 @@ func syncHosts(cloud *Cloud) error {
 			// N.B. gcloud uses the local username to log into instances rather
 			// than the username on the authenticated Google account.
 			tw.Write([]byte(fmt.Sprintf(
-				"%s@%s\t%s\n", osUser.Username, vm.PublicIP, vm.locality())))
+				"%s@%s\t%s\n", config.OSUser.Username, vm.PublicIP, vm.Locality())))
 		}
 		if err := tw.Flush(); err != nil {
 			return errors.Wrapf(err, "problem writing file %s", filename)
@@ -53,8 +54,8 @@ func syncHosts(cloud *Cloud) error {
 	return gcHostsFiles(cloud)
 }
 
-func gcHostsFiles(cloud *Cloud) error {
-	hd := os.ExpandEnv(defaultHostDir)
+func gcHostsFiles(cloud *cloud.Cloud) error {
+	hd := os.ExpandEnv(config.DefaultHostDir)
 	files, err := ioutil.ReadDir(hd)
 	if err != nil {
 		return err
@@ -81,7 +82,7 @@ func newInvalidHostsLineErr(line string) error {
 }
 
 func loadClusters() error {
-	hd := os.ExpandEnv(defaultHostDir)
+	hd := os.ExpandEnv(config.DefaultHostDir)
 	files, err := ioutil.ReadDir(hd)
 	if err != nil {
 		return err
@@ -99,8 +100,8 @@ func loadClusters() error {
 		}
 		lines := strings.Split(string(contents), "\n")
 
-		c := &syncedCluster{
-			name: file.Name(),
+		c := &install.SyncedCluster{
+			Name: file.Name(),
 		}
 
 		for _, l := range lines {
@@ -117,7 +118,7 @@ func loadClusters() error {
 			parts := strings.Split(fields[0], "@")
 			var n, u string
 			if len(parts) == 1 {
-				u = osUser.Username
+				u = config.OSUser.Username
 				n = parts[0]
 			} else if len(parts) == 2 {
 				u = parts[0]
@@ -131,11 +132,11 @@ func loadClusters() error {
 				l = fields[1]
 			}
 
-			c.vms = append(c.vms, n)
-			c.users = append(c.users, u)
-			c.localities = append(c.localities, l)
+			c.VMs = append(c.VMs, n)
+			c.Users = append(c.Users, u)
+			c.Localities = append(c.Localities, l)
 		}
-		clusters[file.Name()] = c
+		install.Clusters[file.Name()] = c
 	}
 
 	return nil

--- a/install/cassandra_yaml.go
+++ b/install/cassandra_yaml.go
@@ -1,4 +1,4 @@
-package main
+package install
 
 const cassandraDiffYAML = `
 commitlog_sync: batch

--- a/install/cluster_synced.go
+++ b/install/cluster_synced.go
@@ -1,4 +1,4 @@
-package main
+package install
 
 import (
 	"bufio"
@@ -18,56 +18,61 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/cockroachdb/roachprod/config"
+	"github.com/cockroachdb/roachprod/ssh"
+	"github.com/cockroachdb/roachprod/ui"
 	"github.com/pkg/errors"
 )
 
-type clusterImpl interface {
-	start(c *syncedCluster)
-	nodeURL(c *syncedCluster, host string, port int) string
-	nodePort(c *syncedCluster, index int) int
+type ClusterImpl interface {
+	Start(c *SyncedCluster)
+	NodeURL(c *SyncedCluster, host string, port int) string
+	NodePort(c *SyncedCluster, index int) int
 }
 
-// A syncedCluster is created from the information in the synced hosts file.
+// A SyncedCluster is created from the information in the synced hosts file
+// and is used as the target for installing and managing various software
+// components.
 //
 // TODO(benesch): unify with CloudCluster.
-type syncedCluster struct {
+type SyncedCluster struct {
 	// name, vms, users, localities are populated at init time.
-	name       string
-	vms        []string
-	users      []string
-	localities []string
+	Name       string
+	VMs        []string
+	Users      []string
+	Localities []string
 	// all other fields are populated in newCluster.
-	nodes   []int
-	loadGen int
-	secure  bool
-	env     string
-	args    []string
-	impl    clusterImpl
+	Nodes   []int
+	LoadGen int
+	Secure  bool
+	Env     string
+	Args    []string
+	Impl    ClusterImpl
 }
 
-func (c *syncedCluster) host(index int) string {
-	return c.vms[index-1]
+func (c *SyncedCluster) host(index int) string {
+	return c.VMs[index-1]
 }
 
-func (c *syncedCluster) user(index int) string {
-	return c.users[index-1]
+func (c *SyncedCluster) user(index int) string {
+	return c.Users[index-1]
 }
 
-func (c *syncedCluster) locality(index int) string {
-	return c.localities[index-1]
+func (c *SyncedCluster) locality(index int) string {
+	return c.Localities[index-1]
 }
 
-func (c *syncedCluster) isLocal() bool {
-	return c.name == local
+func (c *SyncedCluster) IsLocal() bool {
+	return c.Name == config.Local
 }
 
-func (c *syncedCluster) serverNodes() []int {
-	if c.loadGen == -1 {
-		return c.nodes
+func (c *SyncedCluster) ServerNodes() []int {
+	if c.LoadGen == -1 {
+		return c.Nodes
 	}
-	newNodes := make([]int, 0, len(c.nodes))
-	for _, i := range c.nodes {
-		if i != c.loadGen {
+	newNodes := make([]int, 0, len(c.Nodes))
+	for _, i := range c.Nodes {
+		if i != c.LoadGen {
 			newNodes = append(newNodes, i)
 		}
 	}
@@ -75,12 +80,12 @@ func (c *syncedCluster) serverNodes() []int {
 }
 
 // getInternalIP returns the internal IP address of the specified node.
-func (c *syncedCluster) getInternalIP(index int) (string, error) {
-	if c.isLocal() {
+func (c *SyncedCluster) GetInternalIP(index int) (string, error) {
+	if c.IsLocal() {
 		return c.host(index), nil
 	}
 
-	session, err := newSSHSession(c.user(index), c.host(index))
+	session, err := ssh.NewSSHSession(c.user(index), c.host(index))
 	if err != nil {
 		return "", nil
 	}
@@ -94,14 +99,14 @@ func (c *syncedCluster) getInternalIP(index int) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
-func (c *syncedCluster) start() {
-	c.impl.start(c)
+func (c *SyncedCluster) Start() {
+	c.Impl.Start(c)
 }
 
-func (c *syncedCluster) stop() {
-	display := fmt.Sprintf("%s: stopping", c.name)
-	c.parallel(display, len(c.nodes), 0, func(i int) ([]byte, error) {
-		session, err := newSSHSession(c.user(c.nodes[i]), c.host(c.nodes[i]))
+func (c *SyncedCluster) Stop() {
+	display := fmt.Sprintf("%s: stopping", c.Name)
+	c.Parallel(display, len(c.Nodes), 0, func(i int) ([]byte, error) {
+		session, err := ssh.NewSSHSession(c.user(c.Nodes[i]), c.host(c.Nodes[i]))
 		if err != nil {
 			return nil, err
 		}
@@ -110,16 +115,16 @@ func (c *syncedCluster) stop() {
 		cmd := `pkill -9 "cockroach|java|mongo|kv|ycsb" || true ;
 `
 		cmd += fmt.Sprintf("kill -9 $(lsof -t -i :%d -i :%d) 2>/dev/null || true ;\n",
-			cockroach{}.nodePort(c, c.nodes[i]),
-			cassandra{}.nodePort(c, c.nodes[i]))
+			Cockroach{}.NodePort(c, c.Nodes[i]),
+			Cassandra{}.NodePort(c, c.Nodes[i]))
 		return session.CombinedOutput(cmd)
 	})
 }
 
-func (c *syncedCluster) wipe() {
-	display := fmt.Sprintf("%s: wiping", c.name)
-	c.parallel(display, len(c.nodes), 0, func(i int) ([]byte, error) {
-		session, err := newSSHSession(c.user(c.nodes[i]), c.host(c.nodes[i]))
+func (c *SyncedCluster) Wipe() {
+	display := fmt.Sprintf("%s: wiping", c.Name)
+	c.Parallel(display, len(c.Nodes), 0, func(i int) ([]byte, error) {
+		session, err := ssh.NewSSHSession(c.user(c.Nodes[i]), c.host(c.Nodes[i]))
 		if err != nil {
 			return nil, err
 		}
@@ -128,10 +133,10 @@ func (c *syncedCluster) wipe() {
 		cmd := `pkill -9 "cockroach|java|mongo|kv|ycsb" || true ;
 `
 		cmd += fmt.Sprintf("kill -9 $(lsof -t -i :%d -i :%d) 2>/dev/null || true ;\n",
-			cockroach{}.nodePort(c, c.nodes[i]),
-			cassandra{}.nodePort(c, c.nodes[i]))
-		if c.isLocal() {
-			cmd += fmt.Sprintf(`rm -fr ${HOME}/local/cockroach%d ;`, c.nodes[i])
+			Cockroach{}.NodePort(c, c.Nodes[i]),
+			Cassandra{}.NodePort(c, c.Nodes[i]))
+		if c.IsLocal() {
+			cmd += fmt.Sprintf(`rm -fr ${HOME}/local/cockroach%d ;`, c.Nodes[i])
 		} else {
 			cmd += `find /mnt/data* -maxdepth 1 -type f -exec rm -f {} \; ;
 rm -fr /mnt/data*/{auxiliary,local,tmp,cassandra,cockroach,cockroach-temp*,mongo-data} \; ;
@@ -141,11 +146,11 @@ rm -fr /mnt/data*/{auxiliary,local,tmp,cassandra,cockroach,cockroach-temp*,mongo
 	})
 }
 
-func (c *syncedCluster) status() {
-	display := fmt.Sprintf("%s: status", c.name)
-	results := make([]string, len(c.nodes))
-	c.parallel(display, len(c.nodes), 0, func(i int) ([]byte, error) {
-		session, err := newSSHSession(c.user(c.nodes[i]), c.host(c.nodes[i]))
+func (c *SyncedCluster) Status() {
+	display := fmt.Sprintf("%s: status", c.Name)
+	results := make([]string, len(c.Nodes))
+	c.Parallel(display, len(c.Nodes), 0, func(i int) ([]byte, error) {
+		session, err := ssh.NewSSHSession(c.user(c.Nodes[i]), c.host(c.Nodes[i]))
 		if err != nil {
 			results[i] = err.Error()
 			return nil, nil
@@ -153,10 +158,10 @@ func (c *syncedCluster) status() {
 		defer session.Close()
 
 		cmd := fmt.Sprintf("out=$(lsof -i :%d -i :%d -sTCP:LISTEN",
-			cockroach{}.nodePort(c, c.nodes[i]),
-			cassandra{}.nodePort(c, c.nodes[i]))
+			Cockroach{}.NodePort(c, c.Nodes[i]),
+			Cassandra{}.NodePort(c, c.Nodes[i]))
 		cmd += ` | awk '!/COMMAND/ {print $1, $2}' | sort | uniq);
-vers=$(` + binary + ` version 2>/dev/null | awk '/Build Tag:/ {print $NF}')
+vers=$(` + config.Binary + ` version 2>/dev/null | awk '/Build Tag:/ {print $NF}')
 if [ -n "${out}" -a -n "${vers}" ]; then
   echo ${out} | sed "s/cockroach/cockroach-${vers}/g"
 else
@@ -178,22 +183,22 @@ fi
 	})
 
 	for i, r := range results {
-		fmt.Printf("  %2d: %s\n", c.nodes[i], r)
+		fmt.Printf("  %2d: %s\n", c.Nodes[i], r)
 	}
 }
 
 type nodeMonitorInfo struct {
-	index int
-	msg   string
+	Index int
+	Msg   string
 }
 
-func (c *syncedCluster) monitor() chan nodeMonitorInfo {
+func (c *SyncedCluster) Monitor() chan nodeMonitorInfo {
 	ch := make(chan nodeMonitorInfo)
-	nodes := c.serverNodes()
+	nodes := c.ServerNodes()
 
 	for i := range nodes {
 		go func(i int) {
-			session, err := newSSHSession(c.user(nodes[i]), c.host(nodes[i]))
+			session, err := ssh.NewSSHSession(c.user(nodes[i]), c.host(nodes[i]))
 			if err != nil {
 				ch <- nodeMonitorInfo{nodes[i], err.Error()}
 				return
@@ -241,7 +246,7 @@ while :; do
   fi
 done
 `,
-				cockroach{}.nodePort(c, nodes[i]))
+				Cockroach{}.NodePort(c, nodes[i]))
 
 			if err := session.Run(cmd); err != nil {
 				ch <- nodeMonitorInfo{nodes[i], err.Error()}
@@ -253,12 +258,12 @@ done
 	return ch
 }
 
-func (c *syncedCluster) run(w io.Writer, nodes []int, title, cmd string) error {
-	display := fmt.Sprintf("%s: %s", c.name, title)
+func (c *SyncedCluster) Run(w io.Writer, nodes []int, title, cmd string) error {
+	display := fmt.Sprintf("%s: %s", c.Name, title)
 	errors := make([]error, len(nodes))
 	results := make([]string, len(nodes))
-	c.parallel(display, len(nodes), 0, func(i int) ([]byte, error) {
-		session, err := newSSHSession(c.user(nodes[i]), c.host(nodes[i]))
+	c.Parallel(display, len(nodes), 0, func(i int) ([]byte, error) {
+		session, err := ssh.NewSSHSession(c.user(nodes[i]), c.host(nodes[i]))
 		if err != nil {
 			errors[i] = err
 			results[i] = err.Error()
@@ -288,12 +293,12 @@ func (c *syncedCluster) run(w io.Writer, nodes []int, title, cmd string) error {
 	return nil
 }
 
-func (c *syncedCluster) wait() error {
-	display := fmt.Sprintf("%s: waiting for nodes to start", c.name)
-	errs := make([]error, len(c.nodes))
-	c.parallel(display, len(c.nodes), 0, func(i int) ([]byte, error) {
+func (c *SyncedCluster) Wait() error {
+	display := fmt.Sprintf("%s: waiting for nodes to start", c.Name)
+	errs := make([]error, len(c.Nodes))
+	c.Parallel(display, len(c.Nodes), 0, func(i int) ([]byte, error) {
 		for j := 0; j < 600; j++ {
-			session, err := newSSHSession(c.user(c.nodes[i]), c.host(c.nodes[i]))
+			session, err := ssh.NewSSHSession(c.user(c.Nodes[i]), c.host(c.Nodes[i]))
 			if err != nil {
 				time.Sleep(500 * time.Millisecond)
 				continue
@@ -319,7 +324,7 @@ func (c *syncedCluster) wait() error {
 	var foundErr bool
 	for i, err := range errs {
 		if err != nil {
-			fmt.Printf("  %2d: %v\n", c.nodes[i], err)
+			fmt.Printf("  %2d: %v\n", c.Nodes[i], err)
 			foundErr = true
 		}
 	}
@@ -329,20 +334,20 @@ func (c *syncedCluster) wait() error {
 	return nil
 }
 
-func (c *syncedCluster) cockroachVersions() map[string]int {
+func (c *SyncedCluster) CockroachVersions() map[string]int {
 	sha := make(map[string]int)
 	var mu sync.Mutex
 
-	display := fmt.Sprintf("%s: cockroach version", c.name)
-	nodes := c.serverNodes()
-	c.parallel(display, len(nodes), 0, func(i int) ([]byte, error) {
-		session, err := newSSHSession(c.user(c.nodes[i]), c.host(nodes[i]))
+	display := fmt.Sprintf("%s: cockroach version", c.Name)
+	nodes := c.ServerNodes()
+	c.Parallel(display, len(nodes), 0, func(i int) ([]byte, error) {
+		session, err := ssh.NewSSHSession(c.user(c.Nodes[i]), c.host(nodes[i]))
 		if err != nil {
 			return nil, err
 		}
 		defer session.Close()
 
-		cmd := binary + " version | awk '/Build Tag:/ {print $NF}'"
+		cmd := config.Binary + " version | awk '/Build Tag:/ {print $NF}'"
 		out, err := session.CombinedOutput(cmd)
 		var s string
 		if err != nil {
@@ -359,21 +364,21 @@ func (c *syncedCluster) cockroachVersions() map[string]int {
 	return sha
 }
 
-func (c *syncedCluster) runLoad(cmd string, stdout, stderr io.Writer) error {
-	if c.loadGen == 0 {
-		log.Fatalf("%s: no load generator node specified", c.name)
+func (c *SyncedCluster) RunLoad(cmd string, stdout, stderr io.Writer) error {
+	if c.LoadGen == 0 {
+		log.Fatalf("%s: no load generator node specified", c.Name)
 	}
 
-	display := fmt.Sprintf("%s: retrieving IP addresses", c.name)
-	nodes := c.serverNodes()
+	display := fmt.Sprintf("%s: retrieving IP addresses", c.Name)
+	nodes := c.ServerNodes()
 	ips := make([]string, len(nodes))
-	c.parallel(display, len(nodes), 0, func(i int) ([]byte, error) {
+	c.Parallel(display, len(nodes), 0, func(i int) ([]byte, error) {
 		var err error
-		ips[i], err = c.getInternalIP(nodes[i])
+		ips[i], err = c.GetInternalIP(nodes[i])
 		return nil, err
 	})
 
-	session, err := newSSHSession(c.user(c.loadGen), c.host(c.loadGen))
+	session, err := ssh.NewSSHSession(c.user(c.LoadGen), c.host(c.LoadGen))
 	if err != nil {
 		return err
 	}
@@ -398,7 +403,7 @@ func (c *syncedCluster) runLoad(cmd string, stdout, stderr io.Writer) error {
 
 	var urls []string
 	for i, ip := range ips {
-		urls = append(urls, c.impl.nodeURL(c, ip, c.impl.nodePort(c, nodes[i])))
+		urls = append(urls, c.Impl.NodeURL(c, ip, c.Impl.NodePort(c, nodes[i])))
 	}
 	return session.Run("ulimit -n 16384; " + cmd + " " + strings.Join(urls, " "))
 }
@@ -411,30 +416,30 @@ func formatProgress(p float64) string {
 	return fmt.Sprintf("[%s%s] %.0f%%", progressDone[i:], progressTodo[:i], 100*p)
 }
 
-func (c *syncedCluster) put(src, dest string) {
+func (c *SyncedCluster) Put(src, dest string) {
 	// TODO(peter): Only put 10 nodes at a time. When a node completes, output a
 	// line indicating that.
-	fmt.Printf("%s: putting %s %s\n", c.name, src, dest)
+	fmt.Printf("%s: putting %s %s\n", c.Name, src, dest)
 
 	type result struct {
 		index int
 		err   error
 	}
 
-	var writer uiWriter
-	results := make(chan result, len(c.nodes))
-	lines := make([]string, len(c.nodes))
+	var writer ui.Writer
+	results := make(chan result, len(c.Nodes))
+	lines := make([]string, len(c.Nodes))
 	var linesMu sync.Mutex
 
 	var wg sync.WaitGroup
-	for i := range c.nodes {
+	for i := range c.Nodes {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			session, err := newSSHSession(c.user(c.nodes[i]), c.host(c.nodes[i]))
+			session, err := ssh.NewSSHSession(c.user(c.Nodes[i]), c.host(c.Nodes[i]))
 			if err == nil {
 				defer session.Close()
-				err = scpPut(src, dest, func(p float64) {
+				err = ssh.SCPPut(src, dest, func(p float64) {
 					linesMu.Lock()
 					defer linesMu.Unlock()
 					lines[i] = formatProgress(p)
@@ -450,7 +455,7 @@ func (c *syncedCluster) put(src, dest string) {
 	}()
 
 	var ticker *time.Ticker
-	if isStdoutTerminal {
+	if ui.IsStdoutTerminal {
 		ticker = time.NewTicker(100 * time.Millisecond)
 	} else {
 		ticker = time.NewTicker(1000 * time.Millisecond)
@@ -464,7 +469,7 @@ func (c *syncedCluster) put(src, dest string) {
 	for done := false; !done; {
 		select {
 		case <-ticker.C:
-			if !isStdoutTerminal {
+			if !ui.IsStdoutTerminal {
 				fmt.Printf(".")
 			}
 		case r, ok := <-results:
@@ -480,10 +485,10 @@ func (c *syncedCluster) put(src, dest string) {
 				linesMu.Unlock()
 			}
 		}
-		if isStdoutTerminal {
+		if ui.IsStdoutTerminal {
 			linesMu.Lock()
 			for i := range lines {
-				fmt.Fprintf(&writer, "  %2d: ", c.nodes[i])
+				fmt.Fprintf(&writer, "  %2d: ", c.Nodes[i])
 				if lines[i] != "" {
 					fmt.Fprintf(&writer, "%s", lines[i])
 				} else {
@@ -497,11 +502,11 @@ func (c *syncedCluster) put(src, dest string) {
 		}
 	}
 
-	if !isStdoutTerminal {
+	if !ui.IsStdoutTerminal {
 		fmt.Printf("\n")
 		linesMu.Lock()
 		for i := range lines {
-			fmt.Printf("  %2d: %s\n", c.nodes[i], lines[i])
+			fmt.Printf("  %2d: %s\n", c.Nodes[i], lines[i])
 		}
 		linesMu.Unlock()
 	}
@@ -511,35 +516,35 @@ func (c *syncedCluster) put(src, dest string) {
 	}
 }
 
-func (c *syncedCluster) get(src, dest string) {
+func (c *SyncedCluster) Get(src, dest string) {
 	// TODO(peter): Only get 10 nodes at a time. When a node completes, output a
 	// line indicating that.
-	fmt.Printf("%s: getting %s %s\n", c.name, src, dest)
+	fmt.Printf("%s: getting %s %s\n", c.Name, src, dest)
 
 	type result struct {
 		index int
 		err   error
 	}
 
-	var writer uiWriter
-	results := make(chan result, len(c.nodes))
-	lines := make([]string, len(c.nodes))
+	var writer ui.Writer
+	results := make(chan result, len(c.Nodes))
+	lines := make([]string, len(c.Nodes))
 	var linesMu sync.Mutex
 
 	var wg sync.WaitGroup
-	for i := range c.nodes {
+	for i := range c.Nodes {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			session, err := newSSHSession(c.user(c.nodes[i]), c.host(c.nodes[i]))
+			session, err := ssh.NewSSHSession(c.user(c.Nodes[i]), c.host(c.Nodes[i]))
 			if err == nil {
 				defer session.Close()
 				dest := dest
-				if len(c.nodes) > 1 {
-					base := fmt.Sprintf("%d.%s", c.nodes[i], filepath.Base(dest))
+				if len(c.Nodes) > 1 {
+					base := fmt.Sprintf("%d.%s", c.Nodes[i], filepath.Base(dest))
 					dest = filepath.Join(filepath.Dir(dest), base)
 				}
-				err = scpGet(src, dest, func(p float64) {
+				err = ssh.SCPGet(src, dest, func(p float64) {
 					linesMu.Lock()
 					defer linesMu.Unlock()
 					lines[i] = formatProgress(p)
@@ -555,7 +560,7 @@ func (c *syncedCluster) get(src, dest string) {
 	}()
 
 	var ticker *time.Ticker
-	if isStdoutTerminal {
+	if ui.IsStdoutTerminal {
 		ticker = time.NewTicker(100 * time.Millisecond)
 	} else {
 		ticker = time.NewTicker(1000 * time.Millisecond)
@@ -569,7 +574,7 @@ func (c *syncedCluster) get(src, dest string) {
 	for done := false; !done; {
 		select {
 		case <-ticker.C:
-			if !isStdoutTerminal {
+			if !ui.IsStdoutTerminal {
 				fmt.Printf(".")
 			}
 		case r, ok := <-results:
@@ -585,10 +590,10 @@ func (c *syncedCluster) get(src, dest string) {
 				linesMu.Unlock()
 			}
 		}
-		if isStdoutTerminal {
+		if ui.IsStdoutTerminal {
 			linesMu.Lock()
 			for i := range lines {
-				fmt.Fprintf(&writer, "  %2d: ", c.nodes[i])
+				fmt.Fprintf(&writer, "  %2d: ", c.Nodes[i])
 				if lines[i] != "" {
 					fmt.Fprintf(&writer, "%s", lines[i])
 				} else {
@@ -602,11 +607,11 @@ func (c *syncedCluster) get(src, dest string) {
 		}
 	}
 
-	if !isStdoutTerminal {
+	if !ui.IsStdoutTerminal {
 		fmt.Printf("\n")
 		linesMu.Lock()
 		for i := range lines {
-			fmt.Printf("  %2d: %s\n", c.nodes[i], lines[i])
+			fmt.Printf("  %2d: %s\n", c.Nodes[i], lines[i])
 		}
 		linesMu.Unlock()
 	}
@@ -619,30 +624,30 @@ func (c *syncedCluster) get(src, dest string) {
 var parameterRe = regexp.MustCompile(`{[^}]*}`)
 var pgurlRe = regexp.MustCompile(`{pgurl(:[-0-9]+)?}`)
 
-func (c *syncedCluster) pgurls(nodes []int) map[int]string {
+func (c *SyncedCluster) pgurls(nodes []int) map[int]string {
 	ips := make([]string, len(nodes))
-	c.parallel("", len(nodes), 0, func(i int) ([]byte, error) {
+	c.Parallel("", len(nodes), 0, func(i int) ([]byte, error) {
 		var err error
-		ips[i], err = c.getInternalIP(nodes[i])
+		ips[i], err = c.GetInternalIP(nodes[i])
 		return nil, err
 	})
 
 	m := make(map[int]string, len(ips))
 	for i, ip := range ips {
-		m[nodes[i]] = c.impl.nodeURL(c, ip, c.impl.nodePort(c, nodes[i]))
+		m[nodes[i]] = c.Impl.NodeURL(c, ip, c.Impl.NodePort(c, nodes[i]))
 	}
 	return m
 }
 
-func (c *syncedCluster) ssh(args []string) error {
-	if len(c.nodes) != 1 {
-		return fmt.Errorf("invalid number of nodes for ssh: %d", c.nodes)
+func (c *SyncedCluster) Ssh(args []string) error {
+	if len(c.Nodes) != 1 {
+		return fmt.Errorf("invalid number of nodes for ssh: %d", c.Nodes)
 	}
 
 	allArgs := []string{
 		"ssh",
-		fmt.Sprintf("%s@%s", c.user(c.nodes[0]), c.host(c.nodes[0])),
-		"-i", filepath.Join(osUser.HomeDir, ".ssh", "google_compute_engine"),
+		fmt.Sprintf("%s@%s", c.user(c.Nodes[0]), c.host(c.Nodes[0])),
+		"-i", filepath.Join(config.OSUser.HomeDir, ".ssh", "google_compute_engine"),
 		"-o", "StrictHostKeyChecking=no",
 	}
 
@@ -663,10 +668,10 @@ func (c *syncedCluster) ssh(args []string) error {
 			}
 
 			if urls == nil {
-				urls = c.pgurls(allNodes(len(c.vms)))
+				urls = c.pgurls(allNodes(len(c.VMs)))
 			}
 
-			nodes, err := listNodes(m[1], len(c.vms))
+			nodes, err := ListNodes(m[1], len(c.VMs))
 			if err != nil {
 				return err.Error()
 			}
@@ -690,27 +695,27 @@ func (c *syncedCluster) ssh(args []string) error {
 	return syscall.Exec(sshPath, allArgs, os.Environ())
 }
 
-func (c *syncedCluster) stopLoad() {
-	if c.loadGen == 0 {
-		log.Fatalf("no load generator node specified for cluster: %s", c.name)
+func (c *SyncedCluster) stopLoad() {
+	if c.LoadGen == 0 {
+		log.Fatalf("no load generator node specified for cluster: %s", c.Name)
 	}
 
-	display := fmt.Sprintf("%s: stopping load", c.name)
-	c.parallel(display, 1, 0, func(i int) ([]byte, error) {
-		session, err := newSSHSession(c.user(c.loadGen), c.host(c.loadGen))
+	display := fmt.Sprintf("%s: stopping load", c.Name)
+	c.Parallel(display, 1, 0, func(i int) ([]byte, error) {
+		session, err := ssh.NewSSHSession(c.user(c.LoadGen), c.host(c.LoadGen))
 		if err != nil {
 			return nil, err
 		}
 		defer session.Close()
 
 		cmd := fmt.Sprintf("kill -9 $(lsof -t -i :%d -i :%d) 2>/dev/null || true",
-			cockroach{}.nodePort(c, c.nodes[i]),
-			cassandra{}.nodePort(c, c.nodes[i]))
+			Cockroach{}.NodePort(c, c.Nodes[i]),
+			Cassandra{}.NodePort(c, c.Nodes[i]))
 		return session.CombinedOutput(cmd)
 	})
 }
 
-func (c *syncedCluster) parallel(display string, count, concurrency int, fn func(i int) ([]byte, error)) {
+func (c *SyncedCluster) Parallel(display string, count, concurrency int, fn func(i int) ([]byte, error)) {
 	if concurrency == 0 || concurrency > count {
 		concurrency = count
 	}
@@ -744,14 +749,14 @@ func (c *syncedCluster) parallel(display string, count, concurrency int, fn func
 		close(results)
 	}()
 
-	var writer uiWriter
+	var writer ui.Writer
 	out := io.Writer(os.Stdout)
 	if display == "" {
 		out = ioutil.Discard
 	}
 
 	var ticker *time.Ticker
-	if isStdoutTerminal {
+	if ui.IsStdoutTerminal {
 		ticker = time.NewTicker(100 * time.Millisecond)
 	} else {
 		ticker = time.NewTicker(1000 * time.Millisecond)
@@ -768,7 +773,7 @@ func (c *syncedCluster) parallel(display string, count, concurrency int, fn func
 	for done := false; !done; {
 		select {
 		case <-ticker.C:
-			if !isStdoutTerminal {
+			if !ui.IsStdoutTerminal {
 				fmt.Fprintf(out, ".")
 			}
 		case r, ok := <-results:
@@ -784,7 +789,7 @@ func (c *syncedCluster) parallel(display string, count, concurrency int, fn func
 			}
 		}
 
-		if isStdoutTerminal {
+		if ui.IsStdoutTerminal {
 			fmt.Fprint(&writer, display)
 			var n int
 			for i := range complete {
@@ -802,7 +807,7 @@ func (c *syncedCluster) parallel(display string, count, concurrency int, fn func
 		}
 	}
 
-	if !isStdoutTerminal {
+	if !ui.IsStdoutTerminal {
 		fmt.Fprintf(out, "\n")
 	}
 

--- a/install/cockroach.go
+++ b/install/cockroach.go
@@ -1,21 +1,24 @@
-package main
+package install
 
 import (
 	"fmt"
 	"regexp"
 	"strings"
 
+	"github.com/cockroachdb/roachprod/cloud"
+	"github.com/cockroachdb/roachprod/config"
+	"github.com/cockroachdb/roachprod/ssh"
 	"github.com/hashicorp/go-version"
 )
 
-var startOpts struct {
-	sequential bool
+var StartOpts struct {
+	Sequential bool
 }
 
-type cockroach struct{}
+type Cockroach struct{}
 
 func getCockroachVersion(host, user, binary string) (*version.Version, error) {
-	session, err := newSSHSession(user, host)
+	session, err := ssh.NewSSHSession(user, host)
 	if err != nil {
 		return nil, err
 	}
@@ -38,50 +41,50 @@ func getCockroachVersion(host, user, binary string) (*version.Version, error) {
 	return version, nil
 }
 
-func (r cockroach) start(c *syncedCluster) {
-	display := fmt.Sprintf("%s: starting", c.name)
+func (r Cockroach) Start(c *SyncedCluster) {
+	display := fmt.Sprintf("%s: starting", c.Name)
 	host1 := c.host(1)
-	nodes := c.serverNodes()
+	nodes := c.ServerNodes()
 
 	p := 0
-	if startOpts.sequential {
+	if StartOpts.Sequential {
 		p = 1
 	}
-	c.parallel(display, len(nodes), p, func(i int) ([]byte, error) {
+	c.Parallel(display, len(nodes), p, func(i int) ([]byte, error) {
 		host := c.host(nodes[i])
 		user := c.user(nodes[i])
 
-		vers, err := getCockroachVersion(host, user, binary)
+		vers, err := getCockroachVersion(host, user, config.Binary)
 		if err != nil {
 			return nil, err
 		}
 
-		session, err := newSSHSession(user, host)
+		session, err := ssh.NewSSHSession(user, host)
 		if err != nil {
 			return nil, err
 		}
 		defer session.Close()
 
-		port := r.nodePort(c, nodes[i])
+		port := r.NodePort(c, nodes[i])
 
 		var args []string
-		if c.secure {
+		if c.Secure {
 			args = append(args, "--certs-dir=certs")
 		} else {
 			args = append(args, "--insecure")
 		}
 		dir := "/mnt/data1/cockroach"
 		logDir := "${HOME}/logs"
-		if c.isLocal() {
+		if c.IsLocal() {
 			dir = fmt.Sprintf("${HOME}/local/cockroach%d", nodes[i])
 			logDir = fmt.Sprintf("${HOME}/local/cockroach%d/logs", nodes[i])
 		}
 		args = append(args, "--store=path="+dir)
 		args = append(args, "--log-dir="+logDir)
 		args = append(args, "--background")
-		if versionSatifies(vers, ">=1.1") {
+		if cloud.VersionSatifies(vers, ">=1.1") {
 			cache := 25
-			if c.isLocal() {
+			if c.IsLocal() {
 				cache /= len(nodes)
 				if cache == 0 {
 					cache = 1
@@ -96,11 +99,11 @@ func (r cockroach) start(c *syncedCluster) {
 			args = append(args, "--locality="+locality)
 		}
 		if nodes[i] != 1 {
-			args = append(args, fmt.Sprintf("--join=%s:%d", host1, r.nodePort(c, 1)))
+			args = append(args, fmt.Sprintf("--join=%s:%d", host1, r.NodePort(c, 1)))
 		}
-		args = append(args, c.args...)
+		args = append(args, c.Args...)
 		cmd := "mkdir -p " + logDir + "; " +
-			c.env + " " + binary + " start " + strings.Join(args, " ") +
+			c.Env + " " + config.Binary + " start " + strings.Join(args, " ") +
 			" >> " + logDir + "/cockroach.stdout 2>> " + logDir + "/cockroach.stderr"
 		return session.CombinedOutput(cmd)
 	})
@@ -117,15 +120,15 @@ func (r cockroach) start(c *syncedCluster) {
 
 	if bootstrapped {
 		var msg string
-		display = fmt.Sprintf("%s: initializing cluster settings", c.name)
-		c.parallel(display, 1, 0, func(i int) ([]byte, error) {
-			session, err := newSSHSession(c.user(1), c.host(1))
+		display = fmt.Sprintf("%s: initializing cluster settings", c.Name)
+		c.Parallel(display, 1, 0, func(i int) ([]byte, error) {
+			session, err := ssh.NewSSHSession(c.user(1), c.host(1))
 			if err != nil {
 				return nil, err
 			}
 			defer session.Close()
 
-			cmd := binary + ` sql --url ` + r.nodeURL(c, "localhost", r.nodePort(c, 1)) + ` -e "
+			cmd := config.Binary + ` sql --url ` + r.NodeURL(c, "localhost", r.NodePort(c, 1)) + ` -e "
 set cluster setting kv.allocator.stat_based_rebalancing.enabled = false;
 set cluster setting server.remote_debugging.mode = 'any';
 "`
@@ -142,9 +145,9 @@ set cluster setting server.remote_debugging.mode = 'any';
 	}
 }
 
-func (cockroach) nodeURL(c *syncedCluster, host string, port int) string {
+func (Cockroach) NodeURL(c *SyncedCluster, host string, port int) string {
 	url := fmt.Sprintf("'postgres://root@%s:%d", host, port)
-	if c.secure {
+	if c.Secure {
 		url += "?sslcert=certs%2Fnode.crt&sslkey=certs%2Fnode.key&" +
 			"sslrootcert=certs%2Fca.crt&sslmode=verify-full"
 	} else {
@@ -154,10 +157,10 @@ func (cockroach) nodeURL(c *syncedCluster, host string, port int) string {
 	return url
 }
 
-func (cockroach) nodePort(c *syncedCluster, index int) int {
+func (Cockroach) NodePort(c *SyncedCluster, index int) int {
 	const basePort = 26257
 	port := basePort
-	if c.isLocal() {
+	if c.IsLocal() {
 		port += (index - 1) * 2
 	}
 	return port

--- a/install/install.go
+++ b/install/install.go
@@ -1,14 +1,17 @@
-package main
+package install
 
 import (
 	"bytes"
 	"fmt"
 )
 
-func install(c *syncedCluster, args []string) error {
+// Memoizes cluster info for install operations
+var Clusters = map[string]*SyncedCluster{}
+
+func Install(c *SyncedCluster, args []string) error {
 	do := func(title, cmd string) error {
 		var buf bytes.Buffer
-		err := c.run(&buf, c.nodes, "installing "+title, cmd)
+		err := c.Run(&buf, c.Nodes, "installing "+title, cmd)
 		if err != nil {
 			fmt.Print(buf.String())
 		}

--- a/install/nodes.go
+++ b/install/nodes.go
@@ -1,0 +1,56 @@
+package install
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+func allNodes(total int) []int {
+	r := make([]int, total)
+	for i := range r {
+		r[i] = i + 1
+	}
+	return r
+}
+
+func ListNodes(s string, total int) ([]int, error) {
+	if s == "all" {
+		return allNodes(total), nil
+	}
+
+	m := map[int]bool{}
+	for _, p := range strings.Split(s, ",") {
+		parts := strings.Split(p, "-")
+		switch len(parts) {
+		case 1:
+			i, err := strconv.Atoi(parts[0])
+			if err != nil {
+				return nil, err
+			}
+			m[i] = true
+		case 2:
+			from, err := strconv.Atoi(parts[0])
+			if err != nil {
+				return nil, err
+			}
+			to, err := strconv.Atoi(parts[1])
+			if err != nil {
+				return nil, err
+			}
+			for i := from; i <= to; i++ {
+				m[i] = true
+			}
+		default:
+			return nil, fmt.Errorf("unable to parse nodes specification: %s", p)
+		}
+	}
+
+	r := make([]int, 0, len(m))
+	for i := range m {
+		r = append(r, i)
+	}
+	sort.Ints(r)
+	return r, nil
+}

--- a/ui/writer.go
+++ b/ui/writer.go
@@ -1,4 +1,4 @@
-package main
+package ui
 
 import (
 	"bytes"
@@ -10,14 +10,14 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 )
 
-var isStdoutTerminal = terminal.IsTerminal(int(os.Stdout.Fd()))
+var IsStdoutTerminal = terminal.IsTerminal(int(os.Stdout.Fd()))
 
-type uiWriter struct {
+type Writer struct {
 	buf       bytes.Buffer
 	lineCount int
 }
 
-func (w *uiWriter) Flush(out io.Writer) error {
+func (w *Writer) Flush(out io.Writer) error {
 	if len(w.buf.Bytes()) == 0 {
 		return nil
 	}
@@ -33,11 +33,11 @@ func (w *uiWriter) Flush(out io.Writer) error {
 	return err
 }
 
-func (w *uiWriter) Write(b []byte) (n int, err error) {
+func (w *Writer) Write(b []byte) (n int, err error) {
 	return w.buf.Write(b)
 }
 
-func (w *uiWriter) clearLines(out io.Writer) {
+func (w *Writer) clearLines(out io.Writer) {
 	fmt.Fprint(out, strings.Repeat("\033[1A\033[2K\r", w.lineCount))
 	w.lineCount = 0
 }


### PR DESCRIPTION
This is part 1-of-N to add multi-cloud support to roachprod.

I was finding it difficult to understand the structure and relationship of the code in a flat package, so I've taken a first pass at breaking it out into several different packages.  I've tried to keep this change as mechanical as possible, without introducing any logic changes.  I've verified that the tool still fires up and appears to work correctly, but it would be nice to have one of you with an existing workflow ensure it's still doing the right things.

My follow-up plan is to generalize the `cloud.Foo()` callsites to use a supplied `CloudProvider` instance, extracting the existing gcloud and local behaviors into sub-packges within `cloud` and then following up with AWS support.

Naming and code-organization seem to generate a lot of back-and-forth, so maybe it makes sense to organize a desk-review to converge on the details Thursday or Monday?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/62)
<!-- Reviewable:end -->
