### PR TITLE
Give the monitor ssh sessions a valid (non-/dev/null) stdin

### DIFF
--- a/install/cluster_synced.go
+++ b/install/cluster_synced.go
@@ -248,6 +248,13 @@ done
 `,
 				Cockroach{}.NodePort(c, nodes[i]))
 
+			// Give the session a valid stdin pipe so that nc won't exit immediately.
+			inPipe, err := session.StdinPipe()
+			if err != nil {
+				ch <- nodeMonitorInfo{nodes[i], err.Error()}
+				return
+			}
+			defer inPipe.Close()
 			if err := session.Run(cmd); err != nil {
 				ch <- nodeMonitorInfo{nodes[i], err.Error()}
 				return


### PR DESCRIPTION
The ssh session is passed the equivalent of `/dev/null` to stdin, which
is passed along to `nc`. Tell `nc` to not read from stdin which was
causing it to return immediately instead of the expected blocking
behavior.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/63)
<!-- Reviewable:end -->
