### PR TITLE
add sql subcommand

### DIFF
--- a/install/cluster_synced.go
+++ b/install/cluster_synced.go
@@ -668,7 +668,7 @@ func (c *SyncedCluster) pgurls(nodes []int) map[int]string {
 
 func (c *SyncedCluster) Ssh(args []string) error {
 	if len(c.Nodes) != 1 {
-		return fmt.Errorf("invalid number of nodes for ssh: %d", c.Nodes)
+		return fmt.Errorf("invalid number of nodes for ssh: %d", len(c.Nodes))
 	}
 
 	allArgs := []string{

--- a/main.go
+++ b/main.go
@@ -690,7 +690,27 @@ var sshCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+
 		return c.Ssh(args[1:])
+	},
+}
+
+var sqlCmd = &cobra.Command{
+	Use:          "sql <cluster> [args]",
+	Short:        "run `cockroach sql` on a remote cluster",
+	Long:         "Run `cockroach sql` on a remote cluster.",
+	Args:         cobra.MinimumNArgs(1),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c, err := newCluster(args[0], false /* reserveLoadGen */)
+		if err != nil {
+			return err
+		}
+		cockroach, ok := c.Impl.(install.Cockroach)
+		if !ok {
+			return errors.New("sql is only valid on cockroach clusters")
+		}
+		return cockroach.SQL(c, args[1:])
 	},
 }
 
@@ -748,7 +768,7 @@ func main() {
 
 	rootCmd.AddCommand(createCmd, destroyCmd, extendCmd, listCmd, syncCmd, gcCmd,
 		statusCmd, monitorCmd, startCmd, stopCmd, runCmd, wipeCmd, testCmd,
-		installCmd, putCmd, getCmd, sshCmd, pgurlCmd, webCmd, dumpCmd)
+		installCmd, putCmd, getCmd, sshCmd, pgurlCmd, sqlCmd, webCmd, dumpCmd)
 	rootCmd.Flags().BoolVar(
 		&ssh.InsecureIgnoreHostKey, "insecure-ignore-host-key", true, "don't check ssh host keys")
 
@@ -792,7 +812,8 @@ func main() {
 		&concurrency, "concurrency", "c", "1-64", "the concurrency to run each test")
 
 	for _, cmd := range []*cobra.Command{
-		getCmd, putCmd, runCmd, startCmd, statusCmd, stopCmd, testCmd, wipeCmd, pgurlCmd, installCmd,
+		getCmd, putCmd, runCmd, startCmd, statusCmd, stopCmd, testCmd, wipeCmd, pgurlCmd, sqlCmd,
+		installCmd,
 	} {
 		cmd.Flags().BoolVar(
 			&secure, "secure", false, "use a secure cluster")

--- a/ssh/shell.go
+++ b/ssh/shell.go
@@ -1,0 +1,25 @@
+package ssh
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const shellMetachars = "|&;()<> \t\n$\\`"
+
+func Escape(args []string) string {
+	escaped := make([]string, len(args))
+	for i := range args {
+		if strings.ContainsAny(args[i], shellMetachars) {
+			// Argument contains shell metacharacters. Double quote the
+			// argument, and backslash-escape any characters that still have
+			// meaning inside of double quotes.
+			e := regexp.MustCompile("([$`\"\\\\])").ReplaceAllString(args[i], `\$1`)
+			escaped[i] = fmt.Sprintf(`"%s"`, e)
+		} else {
+			escaped[i] = args[i]
+		}
+	}
+	return strings.Join(escaped, " ")
+}


### PR DESCRIPTION
Add a `roachprod sql` subcommand that replicates the behavior of
`crl-sql`. When no arguments are provided, it opens a SQL shell on the
specified node. When arguments are provided, it executes `cockroach sql
ARGS` on all specified nodes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/69)
<!-- Reviewable:end -->
