### PR TITLE
Add {store-dir} expansion

### DIFF
--- a/install/cassandra.go
+++ b/install/cassandra.go
@@ -3,17 +3,18 @@ package install
 import (
 	"bufio"
 	"fmt"
-	"github.com/cockroachdb/roachprod/ssh"
 	"html/template"
 	"io/ioutil"
 	"log"
 	"os"
 	"time"
+
+	"github.com/cockroachdb/roachprod/ssh"
 )
 
 type Cassandra struct{}
 
-func (Cassandra) Start(c *SyncedCluster) {
+func (Cassandra) Start(c *SyncedCluster, extraArgs []string) {
 	yamlPath, err := makeCassandraYAML(c)
 	if err != nil {
 		log.Fatal(err)
@@ -68,6 +69,15 @@ func (Cassandra) Start(c *SyncedCluster) {
 		}
 		return nil, nil
 	})
+}
+
+func (Cassandra) NodeDir(c *SyncedCluster, index int) string {
+	if c.IsLocal() {
+		// TODO(peter): This will require a bit of work to adjust paths in
+		// cassandra.yaml.
+		panic("Cassandra.NodeDir unimplemented")
+	}
+	return "/mnt/data1/cassandra"
 }
 
 func (Cassandra) NodeURL(_ *SyncedCluster, host string, port int) string {

--- a/install/cockroach.go
+++ b/install/cockroach.go
@@ -84,7 +84,7 @@ func getCockroachVersion(c *SyncedCluster, i int, host, user string) (*version.V
 	return version, nil
 }
 
-func (r Cockroach) Start(c *SyncedCluster) {
+func (r Cockroach) Start(c *SyncedCluster, extraArgs []string) {
 	display := fmt.Sprintf("%s: starting", c.Name)
 	host1 := c.host(1)
 	nodes := c.ServerNodes()
@@ -144,7 +144,7 @@ func (r Cockroach) Start(c *SyncedCluster) {
 		if nodes[i] != 1 {
 			args = append(args, fmt.Sprintf("--join=%s:%d", host1, r.NodePort(c, 1)))
 		}
-		args = append(args, c.Args...)
+		args = append(args, extraArgs...)
 
 		binary := cockroachNodeBinary(c, nodes[i])
 		cmd := "mkdir -p " + logDir + "; " +
@@ -198,6 +198,13 @@ SET CLUSTER SETTING enterprise.license = '%s';`, license),
 
 		fmt.Println(msg)
 	}
+}
+
+func (Cockroach) NodeDir(c *SyncedCluster, index int) string {
+	if c.IsLocal() {
+		return os.ExpandEnv(fmt.Sprintf("${HOME}/local/%d/data", index))
+	}
+	return "/mnt/data1/cockroach"
 }
 
 func (Cockroach) NodeURL(c *SyncedCluster, host string, port int) string {

--- a/install/expander.go
+++ b/install/expander.go
@@ -1,0 +1,59 @@
+package install
+
+import (
+	"regexp"
+	"strings"
+)
+
+var parameterRe = regexp.MustCompile(`{[^}]*}`)
+var pgurlRe = regexp.MustCompile(`{pgurl(:[-0-9]+)?}`)
+var storeDirRe = regexp.MustCompile(`{store-dir}`)
+
+type expander struct {
+	urls map[int]string
+}
+
+func (e *expander) maybeExpandPgurl(c *SyncedCluster, s string) (string, bool) {
+	m := pgurlRe.FindStringSubmatch(s)
+	if m == nil {
+		return s, false
+	}
+
+	if m[1] == "" {
+		m[1] = "all"
+	} else {
+		m[1] = m[1][1:]
+	}
+
+	if e.urls == nil {
+		e.urls = c.pgurls(allNodes(len(c.VMs)))
+	}
+
+	nodes, err := ListNodes(m[1], len(c.VMs))
+	if err != nil {
+		return err.Error(), true
+	}
+
+	var result []string
+	for _, i := range nodes {
+		if url, ok := e.urls[i]; ok {
+			result = append(result, url)
+		}
+	}
+	return strings.Join(result, " "), true
+}
+
+func (e *expander) maybeExpandStoreDir(c *SyncedCluster, s string) (string, bool) {
+	return c.Impl.NodeDir(c, c.Nodes[0]), true
+}
+
+func (e *expander) expand(c *SyncedCluster, arg string) string {
+	return parameterRe.ReplaceAllStringFunc(arg, func(s string) string {
+		s, expanded := e.maybeExpandPgurl(c, s)
+		if expanded {
+			return s
+		}
+		s, _ = e.maybeExpandStoreDir(c, s)
+		return s
+	})
+}


### PR DESCRIPTION
Added template expansion to the `start` arguments. This allows
`roachprod start <cluster> -a --store={store-dir}.new` in order to
change the store directory. `roachprod ssh <node> echo {store-dir}` can
be used to access the store directory for a node.

See https://github.com/cockroachdb/cockroach/issues/22846

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/75)
<!-- Reviewable:end -->
