### PR TITLE
Add --external flag to pgurl subcommand

### DIFF
--- a/install/cluster_synced.go
+++ b/install/cluster_synced.go
@@ -79,7 +79,7 @@ func (c *SyncedCluster) ServerNodes() []int {
 	return newNodes
 }
 
-// getInternalIP returns the internal IP address of the specified node.
+// GetInternalIP returns the internal IP address of the specified node.
 func (c *SyncedCluster) GetInternalIP(index int) (string, error) {
 	if c.IsLocal() {
 		return c.host(index), nil


### PR DESCRIPTION
This causes it to return pgurls that can be used to connect from outside
the cluster. This will be used in roachtest.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/76)
<!-- Reviewable:end -->
