### PR TITLE
Fix COCKROACH_DEV_LICENSE warning

### DIFF
--- a/install/cockroach.go
+++ b/install/cockroach.go
@@ -2,7 +2,6 @@ package install
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -167,6 +166,12 @@ func (r Cockroach) Start(c *SyncedCluster, extraArgs []string) {
 	}
 
 	if bootstrapped {
+		license := os.Getenv("COCKROACH_DEV_LICENSE")
+		if license == "" {
+			fmt.Printf("%s: COCKROACH_DEV_LICENSE unset: enterprise features will be unavailable\n",
+				c.Name)
+		}
+
 		var msg string
 		display = fmt.Sprintf("%s: initializing cluster settings", c.Name)
 		c.Parallel(display, 1, 0, func(i int) ([]byte, error) {
@@ -175,11 +180,6 @@ func (r Cockroach) Start(c *SyncedCluster, extraArgs []string) {
 				return nil, err
 			}
 			defer session.Close()
-
-			license := os.Getenv("COCKROACH_DEV_LICENSE")
-			if license == "" {
-				log.Printf("warning: COCKROACH_DEV_LICENSE unset: enterprise features will be unavailable")
-			}
 
 			binary := cockroachNodeBinary(c, 1)
 			cmd := ssh.Escape([]string{


### PR DESCRIPTION
Fix the dev license warning so that it doesn't get appended to the
"initializing cluster settings" line.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/82)
<!-- Reviewable:end -->
