### PR TITLE
Make `get` work with local clusters

### DIFF
--- a/install/cockroach.go
+++ b/install/cockroach.go
@@ -123,7 +123,7 @@ func (r Cockroach) Start(c *SyncedCluster, extraArgs []string) {
 		logDir := "${HOME}/logs"
 		if c.IsLocal() {
 			dir = fmt.Sprintf("${HOME}/local/%d/data", nodes[i])
-			logDir = fmt.Sprintf("${HOME}/local/%d/data/logs", nodes[i])
+			logDir = fmt.Sprintf("${HOME}/local/%d/logs", nodes[i])
 		}
 		args = append(args, "--store=path="+dir)
 		args = append(args, "--log-dir="+logDir)


### PR DESCRIPTION
It failed to account for the alternative home dir.
Also move the `logs` dir for local cockroach clusters out of the
data directory. The upshot is that `roachprod get logs` will work
both for local and non-local clusters (which is something that
`roachtest` cares about).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/83)
<!-- Reviewable:end -->
