### PR TITLE
Fix the `sql` command to work properly against local clusters

### DIFF
--- a/install/cluster_synced.go
+++ b/install/cluster_synced.go
@@ -664,7 +664,7 @@ func (c *SyncedCluster) pgurls(nodes []int) map[int]string {
 	return m
 }
 
-func (c *SyncedCluster) Ssh(args []string) error {
+func (c *SyncedCluster) Ssh(sshArgs, args []string) error {
 	if len(c.Nodes) != 1 {
 		return fmt.Errorf("invalid number of nodes for ssh: %d", len(c.Nodes))
 	}
@@ -675,6 +675,7 @@ func (c *SyncedCluster) Ssh(args []string) error {
 		"-i", filepath.Join(config.OSUser.HomeDir, ".ssh", "google_compute_engine"),
 		"-o", "StrictHostKeyChecking=no",
 	}
+	allArgs = append(allArgs, sshArgs...)
 	if len(args) > 0 {
 		allArgs = append(allArgs, "ROACHPROD=true")
 	}

--- a/main.go
+++ b/main.go
@@ -674,7 +674,7 @@ var sshCmd = &cobra.Command{
 			return err
 		}
 
-		return c.Ssh(args[1:])
+		return c.Ssh(nil, args[1:])
 	},
 }
 


### PR DESCRIPTION
The binary and port are node specific for local clusters. Pass any ssh
args as a separate slice to `SyncedCluster.Ssh` so they can be placed at
the proper spot in the command line.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/84)
<!-- Reviewable:end -->
