### PR TITLE
Automatically generate certs for secure clusters

### DIFF
--- a/install/cluster_synced.go
+++ b/install/cluster_synced.go
@@ -139,10 +139,11 @@ func (c *SyncedCluster) Wipe() {
 
 		var cmd string
 		if c.IsLocal() {
-			cmd = fmt.Sprintf(`rm -fr ${HOME}/local/%d/{logs,data} ;`, c.Nodes[i])
+			cmd = fmt.Sprintf(`rm -fr ${HOME}/local/%d/{certs*,data,logs} ;`, c.Nodes[i])
 		} else {
 			cmd = `find /mnt/data* -maxdepth 1 -type f -exec rm -f {} \; ;
 rm -fr /mnt/data*/{auxiliary,local,tmp,cassandra,cockroach,cockroach-temp*,mongo-data} \; ;
+rm -fr certs* ;
 `
 		}
 		return session.CombinedOutput(cmd)


### PR DESCRIPTION
`roachprod start <cluster> --secure` now generates a ca, client and node
cert and distributes these certs to every node in the cluster. The certs
are only created the first time the cluster is started (and require node
1 to be started, but that's required by other bootstrapping stuff too).

```
  peter-test: checking certs 1/1
  peter-test: initializing certs 1/1
  peter-test: initializing certs 3/3
  peter-test: starting 4/4
  ...
```

Fixes #85

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/87)
<!-- Reviewable:end -->
