### PR TITLE
Accurately display when clusters will be destroyed

### DIFF
--- a/cloud/cluster_cloud.go
+++ b/cloud/cluster_cloud.go
@@ -78,8 +78,15 @@ func (c *CloudCluster) ExpiresAt() time.Time {
 	return c.CreatedAt.Add(c.Lifetime)
 }
 
+func (c *CloudCluster) GCAt() time.Time {
+	// NB: GC is performed every hour. We calculate the lifetime of the cluster
+	// taking the GC time into account to accurately reflect when the cluster
+	// will be destroyed.
+	return c.ExpiresAt().Add(time.Hour - 1).Truncate(time.Hour)
+}
+
 func (c *CloudCluster) LifetimeRemaining() time.Duration {
-	return time.Until(c.ExpiresAt())
+	return time.Until(c.GCAt())
 }
 
 func (c *CloudCluster) String() string {

--- a/main.go
+++ b/main.go
@@ -54,7 +54,6 @@ var (
 	numNodes       int
 	username       string
 	dryrun         bool
-	destroyAfter   time.Duration
 	extendLifetime time.Duration
 	listDetails    bool
 	listMine       bool
@@ -451,7 +450,7 @@ hosts file.
 
 		// Filter and sort by cluster names for stable output
 		var names []string
-		for name, _ := range cloud.Clusters {
+		for name := range cloud.Clusters {
 			if listPattern.MatchString(name) {
 				names = append(names, name)
 			}
@@ -572,7 +571,7 @@ hourly by a cronjob so it is not necessary to run manually.
 		if err != nil {
 			return err
 		}
-		return cld.GCClusters(cloud, dryrun, destroyAfter)
+		return cld.GCClusters(cloud, dryrun)
 	}),
 }
 
@@ -1072,8 +1071,6 @@ func main() {
 	gcCmd.Flags().BoolVarP(
 		&dryrun, "dry-run", "n", dryrun, "dry run (don't perform any actions)")
 	gcCmd.Flags().StringVar(&config.SlackToken, "slack-token", "", "Slack bot token")
-	gcCmd.Flags().DurationVar(&destroyAfter,
-		"destroy-after", 6*time.Hour, "Destroy when this much time past expiration")
 
 	pgurlCmd.Flags().BoolVar(
 		&external, "external", false, "return pgurls for external connections")


### PR DESCRIPTION
Take the frequency of the `roachprod gc` cronjob into account when
computing the lifetime remaining for clusters. Remove the
`--destroy-after` flag which added a confusing extra bit of life to
clusters and had me perpetually confused about when a cluster would
actually be destroyed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/90)
<!-- Reviewable:end -->
