### PR TITLE
Remove display of the active account from "list"

### DIFF
--- a/main.go
+++ b/main.go
@@ -384,7 +384,6 @@ The default output shows one line per cluster, including the local cluster if
 it exists:
 
   ~ roachprod list
-  Account: marc
   local:     [local]    1  (-)
   marc-test: [aws gce]  4  (5h34m35s)
   Syncing...
@@ -398,7 +397,6 @@ local clusters do not have an expiration.
 The --details adjusts the output format to include per-node details:
 
   ~ roachprod list --details
-  Account: marc
   local [local]: (no expiration)
     localhost		127.0.0.1	127.0.0.1
   marc-test: [aws gce] 5h33m57s remaining
@@ -420,7 +418,6 @@ hosts file.
 		if err != nil {
 			return err
 		}
-		fmt.Printf("Account: %s\n", account)
 
 		listPattern := regexp.MustCompile(".*")
 		switch len(args) {


### PR DESCRIPTION
This was present from the initial version of roachprod, but it isn't
clear what problem it is solving.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/92)
<!-- Reviewable:end -->
