### PR TITLE
Add AWS support to roachprod

### DIFF
--- a/install/cluster_synced.go
+++ b/install/cluster_synced.go
@@ -41,6 +41,7 @@ type SyncedCluster struct {
 	VMs        []string
 	Users      []string
 	Localities []string
+	VPCs       []string
 	// all other fields are populated in newCluster.
 	Nodes   []int
 	LoadGen int

--- a/install/cockroach.go
+++ b/install/cockroach.go
@@ -235,6 +235,17 @@ tar cvf certs.tar certs
 	host1 := c.host(1)
 	nodes := c.ServerNodes()
 
+	// If we're creating nodes that span VPC (e.g. AWS multi-region or
+	// multi-cloud), we'll tell the nodes to advertise their public IPs
+	// so that attaching nodes to the cluster Just Works.
+	var advertisePublicIP bool
+	for i, vpc := range c.VPCs {
+		if i > 0 && vpc != c.VPCs[0] {
+			advertisePublicIP = true
+			break
+		}
+	}
+
 	p := 0
 	if StartOpts.Sequential {
 		p = 1
@@ -293,6 +304,9 @@ tar cvf certs.tar certs
 		}
 		if nodes[i] != 1 {
 			args = append(args, fmt.Sprintf("--join=%s:%d", host1, r.NodePort(c, 1)))
+		}
+		if advertisePublicIP {
+			args = append(args, fmt.Sprintf("--advertise-host=%s", host))
 		}
 		args = append(args, extraArgs...)
 

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/roachprod/ssh"
 	"github.com/cockroachdb/roachprod/ui"
 	"github.com/cockroachdb/roachprod/vm"
+	_ "github.com/cockroachdb/roachprod/vm/aws"
 	"github.com/cockroachdb/roachprod/vm/gce"
 	"github.com/cockroachdb/roachprod/vm/local"
 	"github.com/pkg/errors"
@@ -1050,7 +1051,7 @@ func main() {
 		"nodes", "n", 4, "Total number of nodes, distributed across all clouds")
 	createCmd.Flags().StringSliceVarP(&createVMOpts.VMProviders,
 		"clouds", "c", []string{gce.ProviderName},
-		"The cloud provider(s) to use when creating new vm instances")
+		fmt.Sprintf("The cloud provider(s) to use when creating new vm instances: %s", vm.AllProviderNames()))
 	createCmd.Flags().BoolVar(&createVMOpts.GeoDistributed,
 		"geo", false, "Create geo-distributed cluster")
 	// Allow each Provider to inject additional configuration flags

--- a/vm/aws/aws.go
+++ b/vm/aws/aws.go
@@ -1,0 +1,500 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cockroachdb/roachprod/vm"
+	"github.com/pkg/errors"
+	"github.com/spf13/pflag"
+	"golang.org/x/sync/errgroup"
+)
+
+const ProviderName = "aws"
+
+// init will inject the AWS provider into vm.Providers, but only
+// if the aws tool is available on the local path.
+func init() {
+	if _, err := exec.LookPath("aws"); err == nil {
+		vm.Providers[ProviderName] = &Provider{}
+	} else {
+		log.Printf("please install the AWS CLI utilities " +
+			"(https://docs.aws.amazon.com/cli/latest/userguide/installing.html)")
+	}
+}
+
+// providerOpts implements the vm.ProviderFlags interface for aws.Provider.
+type providerOpts struct {
+	AMI            []string
+	MachineType    string
+	SecurityGroups []string
+	Subnets        []string
+	RemoteUserName string
+}
+
+// ConfigureCreateFlags is part of the vm.ProviderFlags interface.
+// This method sets up a lot of maps between the various EC2
+// regions and the ids of the things we want to use there.  This is
+// somewhat complicated because different EC2 regions may as well
+// be parallel universes.
+func (o *providerOpts) ConfigureCreateFlags(flags *pflag.FlagSet) {
+	// You can find AMI ids here https://cloud-images.ubuntu.com/locator/ec2/
+	// Ubuntu Server 16.04 LTS (HVM), SSD Volume Type
+	flags.StringSliceVar(&o.AMI, ProviderName+"-ami",
+		[]string{
+			"us-east-2:ami-965e6bf3",
+			"us-west-2:ami-79873901",
+		},
+		"AMI images for each region")
+
+	// m5.xlarge is a 4core, 16Gb instance, approximately equal to a GCE n1-standard-4
+	flags.StringVar(&o.MachineType, ProviderName+"-machine-type", "m5.xlarge",
+		"Machine type (see https://aws.amazon.com/ec2/instance-types/)")
+
+	// The subnet actually controls placement into a particular AZ
+	flags.StringSliceVar(&o.Subnets, ProviderName+"-subnet",
+		[]string{
+			// m5 machines not yet available in us-east-2a.
+			// "us-east-2a:subnet-3ea05c57",
+			"us-east-2b:subnet-49170331",
+			"us-east-2c:subnet-46c7f20c",
+			"us-west-2a:subnet-fc46638b",
+			"us-west-2b:subnet-2910174c",
+			"us-west-2c:subnet-da2a5783",
+		},
+		"Subnet id for zones in each region")
+
+	// Set up a roachprod security group in each region
+	flags.StringSliceVar(&o.SecurityGroups, ProviderName+"-sg",
+		[]string{
+			"us-east-2:sg-06a4c809644e32920",
+			"us-west-2:sg-00dfe24958e988576"},
+		"Security group id in each region")
+
+	// AWS images generally use "ubuntu" or "ec2-user"
+	flags.StringVar(&o.RemoteUserName, ProviderName+"-user",
+		"ubuntu", "Name of the remote user to SSH as")
+}
+
+// Provider implements the vm.Provider interface for AWS.
+type Provider struct {
+	opts providerOpts
+}
+
+// CleanSSH is part of vm.Provider.  This implementation is a no-op,
+// since we depend on the user's local identity file.
+func (p *Provider) CleanSSH() error {
+	return nil
+}
+
+// ConfigSSH ensures that for each region we're operating in, we have
+// a <user>-<hash> keypair where <hash> is a hash of the public key.
+// We use a hash since a user probably has multiple machines they're
+// running roachprod on and these machines (ought to) have separate
+// ssh keypairs.  If the remote keypair doesn't exist, we'll upload
+// the user's ~/.ssh/id_rsa.pub file or ask them to generate one.
+func (p *Provider) ConfigSSH() error {
+	keyName, err := p.sshKeyName()
+	if err != nil {
+		return err
+	}
+
+	regions, err := p.allRegions()
+	if err != nil {
+		return err
+	}
+
+	var g errgroup.Group
+	for _, r := range regions {
+		// capture loop variable
+		region := r
+		g.Go(func() error {
+			exists, err := sshKeyExists(keyName, region)
+			if err != nil {
+				return err
+			}
+			if !exists {
+				err = sshKeyImport(keyName, region)
+				if err != nil {
+					return err
+				}
+				log.Printf("imported %s as %s in region %s",
+					sshPublicKeyFile, keyName, region)
+			}
+			return nil
+		})
+	}
+
+	return g.Wait()
+}
+
+// Create is part of the vm.Provider interface.
+func (p *Provider) Create(names []string, opts vm.CreateOpts) error {
+	// We need to make sure that the SSH keys have been distributed to all regions
+	if err := p.ConfigSSH(); err != nil {
+		return err
+	}
+
+	var placements []string
+	regions, err := p.allRegions()
+	if err != nil {
+		return err
+	}
+
+	for _, region := range regions {
+		zones, err := p.allZones(region)
+		if err != nil {
+			return err
+		}
+		placements = append(placements, zones...)
+
+		// Only use one region if we're not creating a distributed cluster
+		if !opts.GeoDistributed {
+			break
+		}
+	}
+
+	var g errgroup.Group
+
+	var pIdx int
+	for _, name := range names {
+		// capture loop variable
+		capName := name
+		placement := placements[pIdx]
+		g.Go(func() error {
+			return p.runInstance(capName, placement, opts)
+		})
+		pIdx = (pIdx + 1) % len(placements)
+	}
+
+	return g.Wait()
+}
+
+// Delete is part of vm.Provider.
+// This will delete all instances in a single AWS command.
+func (p *Provider) Delete(vms vm.List) error {
+	byRegion, err := regionMap(vms)
+	if err != nil {
+		return err
+	}
+	g := errgroup.Group{}
+	for region, list := range byRegion {
+		args := []string{
+			"ec2", "terminate-instances",
+			"--region", region,
+			"--instance-ids",
+		}
+		args = append(args, list.ProviderIDs()...)
+		g.Go(func() error {
+			var data struct {
+				TerminatingInstances []struct {
+					InstanceId string
+				}
+			}
+			return runJSONCommand(args, &data)
+		})
+	}
+	return g.Wait()
+}
+
+// Extend is part of the vm.Provider interface.
+// This will update the Lifetime tag on the instances.
+func (p *Provider) Extend(vms vm.List, lifetime time.Duration) error {
+	byRegion, err := regionMap(vms)
+	if err != nil {
+		return err
+	}
+	g := errgroup.Group{}
+	for region, list := range byRegion {
+		// Capture loop vars here
+		args := []string{
+			"ec2", "create-tags",
+			"--region", region,
+			"--tags", "Key=Lifetime,Value=" + lifetime.String(),
+			"--resources",
+		}
+		args = append(args, list.ProviderIDs()...)
+
+		g.Go(func() error {
+			return runCommand(args)
+		})
+	}
+	return g.Wait()
+}
+
+// cachedActiveAccount memoizes the return value from FindActiveAccount
+var cachedActiveAccount string
+
+// FindActiveAccount is part of the vm.Provider interface.
+// This queries the AWS command for the current IAM user.
+func (p *Provider) FindActiveAccount() (string, error) {
+	if len(cachedActiveAccount) > 0 {
+		return cachedActiveAccount, nil
+	}
+	var userInfo struct {
+		User struct {
+			UserName string
+		}
+	}
+	args := []string{"iam", "get-user"}
+	runJSONCommand(args, &userInfo)
+	cachedActiveAccount = userInfo.User.UserName
+	return cachedActiveAccount, nil
+}
+
+// Flags is part of the vm.Provider interface.
+func (p *Provider) Flags() vm.ProviderFlags {
+	return &p.opts
+}
+
+// List is part of the vm.Provider interface.
+func (p *Provider) List() (vm.List, error) {
+	regions, err := p.allRegions()
+	if err != nil {
+		return nil, err
+	}
+
+	var ret vm.List
+	var mux sync.Mutex
+	var g errgroup.Group
+
+	for _, r := range regions {
+		// capture loop variable
+		region := r
+		g.Go(func() error {
+			vms, err := p.listRegion(region)
+			if err != nil {
+				return err
+			}
+			mux.Lock()
+			ret = append(ret, vms...)
+			mux.Unlock()
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+// Name is part of the vm.Provider interface. This returns "aws".
+func (p *Provider) Name() string {
+	return ProviderName
+}
+
+// allRegions returns the regions that have been configured with
+// AMI and SecurityGroup instances.
+func (p *Provider) allRegions() ([]string, error) {
+	amiMap, err := splitMap(p.opts.AMI)
+	if err != nil {
+		return nil, err
+	}
+
+	securityMap, err := splitMap(p.opts.SecurityGroups)
+	if err != nil {
+		return nil, err
+	}
+
+	var keys []string
+	for region := range amiMap {
+		if _, ok := securityMap[region]; ok {
+			keys = append(keys, region)
+		} else {
+			log.Printf("ignoring region %s because it has no associated SecurityGroup", region)
+		}
+	}
+	return keys, nil
+}
+
+// allZones returns all AWS availability zones which have been correctly
+// configured within the given region.
+func (p *Provider) allZones(region string) ([]string, error) {
+	subnetMap, err := splitMap(p.opts.Subnets)
+	if err != nil {
+		return nil, err
+	}
+
+	var ret []string
+	for zone := range subnetMap {
+		if strings.Index(zone, region) == 0 && len(zone) == len(region)+1 {
+			ret = append(ret, zone)
+		}
+	}
+
+	return ret, nil
+}
+
+// listRegion extracts the roachprod-managed instances in the
+// given region.
+func (p *Provider) listRegion(region string) (vm.List, error) {
+	var data struct {
+		Reservations []struct {
+			Instances []struct {
+				InstanceId string
+				LaunchTime string
+				Placement  struct {
+					AvailabilityZone string
+				}
+				PrivateDnsName   string
+				PrivateIpAddress string
+				PublicDnsName    string
+				PublicIpAddress  string
+				State            struct {
+					Code int
+					Name string
+				}
+				Tags []struct {
+					Key   string
+					Value string
+				}
+				VpcId string
+			}
+		}
+	}
+	args := []string{
+		"ec2", "describe-instances",
+		"--region", region,
+	}
+	err := runJSONCommand(args, &data)
+	if err != nil {
+		return nil, err
+	}
+
+	var ret vm.List
+	for _, res := range data.Reservations {
+	in:
+		for _, in := range res.Instances {
+			// Ignore any instances that are not pending or running
+			if in.State.Name != "pending" && in.State.Name != "running" {
+				continue in
+			}
+
+			// Convert the tag map into a more useful representation
+			tagMap := make(map[string]string, len(in.Tags))
+			for _, entry := range in.Tags {
+				tagMap[entry.Key] = entry.Value
+			}
+			// Ignore any instances that we didn't create
+			if tagMap["Roachprod"] != "true" {
+				continue in
+			}
+
+			var errs []error
+			createdAt, err := time.Parse(time.RFC3339, in.LaunchTime)
+			if err != nil {
+				errs = append(errs, vm.ErrNoExpiration)
+			}
+
+			var lifetime time.Duration
+			if lifeText, ok := tagMap["Lifetime"]; ok {
+				lifetime, err = time.ParseDuration(lifeText)
+				if err != nil {
+					errs = append(errs, err)
+				}
+			} else {
+				errs = append(errs, vm.ErrNoExpiration)
+			}
+
+			m := vm.VM{
+				CreatedAt:  createdAt,
+				DNS:        in.PrivateDnsName,
+				Name:       tagMap["Name"],
+				Errors:     errs,
+				Lifetime:   lifetime,
+				PrivateIP:  in.PrivateIpAddress,
+				Provider:   ProviderName,
+				ProviderID: in.InstanceId,
+				PublicIP:   in.PublicIpAddress,
+				RemoteUser: p.opts.RemoteUserName,
+				VPC:        in.VpcId,
+				Zone:       in.Placement.AvailabilityZone,
+			}
+			ret = append(ret, m)
+		}
+	}
+
+	return ret, nil
+}
+
+// runInstance is responsible for allocating a single ec2 vm.
+// Given that every AWS region may as well be a parallel dimension,
+// we need to do a bit of work to look up all of the various ids that
+// we need in order to actually allocate an instance.
+func (p *Provider) runInstance(name string, zone string, opts vm.CreateOpts) error {
+	region, err := zoneToRegion(zone)
+	if err != nil {
+		return err
+	}
+
+	amiMap, err := splitMap(p.opts.AMI)
+	if err != nil {
+		return err
+	}
+	amiId, ok := amiMap[region]
+	if !ok {
+		return errors.Errorf("could not find an AMI image id for region %s", region)
+	}
+
+	keyName, err := p.sshKeyName()
+	if err != nil {
+		return err
+	}
+
+	sgMap, err := splitMap(p.opts.SecurityGroups)
+	if err != nil {
+		return err
+	}
+	sgId, ok := sgMap[region]
+	if !ok {
+		return errors.Errorf("could not find a security group id for region %s", region)
+	}
+
+	subnetMap, err := splitMap(p.opts.Subnets)
+	if err != nil {
+		return err
+	}
+	subnetId, ok := subnetMap[zone]
+	if !ok {
+		return errors.Errorf("could not find a subnet id for zone %s", zone)
+	}
+
+	// We avoid the need to make a second call to set the tags by jamming
+	// all of our metadata into the TagSpec.
+	tagSpecs := fmt.Sprintf(
+		"ResourceType=instance,Tags=["+
+			"{Key=Lifetime,Value=%s},"+
+			"{Key=Name,Value=%s},"+
+			"{Key=Roachprod,Value=true},"+
+			"]", opts.Lifetime, name)
+
+	var data struct {
+		Instances []struct {
+			InstanceId string
+		}
+	}
+
+	args := []string{
+		"ec2", "run-instances",
+		"--associate-public-ip-address",
+		// Size is measured in GB.  gp2 type derives guaranteed iops from size.
+		"--block-device-mapping", "DeviceName=/dev/sdd,Ebs={VolumeSize=500,VolumeType=gp2,DeleteOnTermination=true}",
+		"--count", "1",
+		"--image-id", amiId,
+		"--instance-type", p.opts.MachineType,
+		"--key-name", keyName,
+		"--region", region,
+		"--security-group-ids", sgId,
+		"--subnet-id", subnetId,
+		"--tag-specifications", tagSpecs,
+		"--user-data", awsStartupScript,
+	}
+
+	return runJSONCommand(args, &data)
+}

--- a/vm/aws/keys.go
+++ b/vm/aws/keys.go
@@ -1,0 +1,84 @@
+package aws
+
+import (
+	"crypto/sha1"
+	"encoding/base64"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/pkg/errors"
+)
+
+const sshPublicKeyFile = "${HOME}/.ssh/id_rsa.pub"
+
+// sshKeyExists checks to see if there is a an SSH key with the given name in the given region.
+func sshKeyExists(keyName string, region string) (bool, error) {
+	var data struct {
+		KeyPairs []struct {
+			KeyName string
+		}
+	}
+	args := []string{
+		"ec2", "describe-key-pairs",
+		"--region", region,
+	}
+	err := runJSONCommand(args, &data)
+	if err != nil {
+		return false, err
+	}
+	for _, keyPair := range data.KeyPairs {
+		if keyPair.KeyName == keyName {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// sshKeyImport takes the user's local, public SSH key and imports it into the ec2 region so that
+// we can create new hosts with it.
+func sshKeyImport(keyName string, region string) error {
+	keyBytes, err := ioutil.ReadFile(os.ExpandEnv(sshPublicKeyFile))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return errors.Wrapf(err, "please run ssh-keygen externally to create your %s file", sshPublicKeyFile)
+		}
+		return err
+	}
+
+	var data struct {
+		KeyName string
+	}
+	args := []string{
+		"ec2", "import-key-pair",
+		"--region", region,
+		"--key-name", keyName,
+		"--public-key-material", string(keyBytes),
+	}
+	return runJSONCommand(args, &data)
+}
+
+// sshKeyName computes the name of the ec2 ssh key that we'll store the local user's public key in
+func (p *Provider) sshKeyName() (string, error) {
+	user, err := p.FindActiveAccount()
+	if err != nil {
+		return "", err
+	}
+
+	keyBytes, err := ioutil.ReadFile(os.ExpandEnv(sshPublicKeyFile))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", errors.Wrapf(err, "please run ssh-keygen externally to create your %s file", sshPublicKeyFile)
+		}
+		return "", err
+	}
+
+	hash := sha1.New()
+	if _, err := hash.Write(keyBytes); err != nil {
+		return "", err
+	}
+	hashBytes := hash.Sum(make([]byte, 0, hash.BlockSize()))
+	hashText := base64.URLEncoding.EncodeToString(hashBytes)
+
+	return fmt.Sprintf("%s-%s", user, hashText), nil
+}

--- a/vm/aws/support.go
+++ b/vm/aws/support.go
@@ -1,0 +1,88 @@
+package aws
+
+import (
+	"encoding/json"
+	"log"
+	"os/exec"
+	"strings"
+
+	"github.com/cockroachdb/roachprod/vm"
+	"github.com/pkg/errors"
+)
+
+// We're using an M5 type machine, which exposes EBS volumes as though they were locally-attached NVMe
+// block devices.  This user-data script will create a filesystem, mount the data volume, and chown it to
+// the ubuntu user which will be running the cockroach binary.
+// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html
+const awsStartupScript = `#!/usr/bin/env bash
+set -e
+mkfs.ext4 /dev/nvme1n1
+mkdir -p /mnt/data1
+mount /dev/nvme1n1 /mnt/data1
+chown -R ubuntu:ubuntu /mnt/data1
+`
+
+// runCommand is used to invoke an AWS command for which no output is expected.
+func runCommand(args []string) error {
+	cmd := exec.Command("aws", args...)
+
+	_, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			log.Println(string(exitErr.Stderr))
+		}
+		return errors.Wrapf(err, "failed to run: aws %s", strings.Join(args, " "))
+	}
+	return nil
+}
+
+// runJSONCommand invokes an aws command and parses the json output.
+func runJSONCommand(args []string, parsed interface{}) error {
+	cmd := exec.Command("aws", args...)
+
+	rawJSON, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			log.Println(string(exitErr.Stderr))
+		}
+		return errors.Wrapf(err, "failed to run: aws %s", strings.Join(args, " "))
+	}
+
+	if err := json.Unmarshal(rawJSON, &parsed); err != nil {
+		return errors.Wrapf(err, "failed to parse json %s", rawJSON)
+	}
+
+	return nil
+}
+
+// splitMap splits a list of `key:value` pairs into a map.
+func splitMap(data []string) (map[string]string, error) {
+	ret := make(map[string]string, len(data))
+	for _, part := range data {
+		parts := strings.Split(part, ":")
+		if len(parts) != 2 {
+			return nil, errors.Errorf("Could not split Region:AMI: %s", part)
+		}
+		ret[parts[0]] = parts[1]
+	}
+	return ret, nil
+}
+
+// regionMap collates VM instances by their region.
+func regionMap(vms vm.List) (map[string]vm.List, error) {
+	// Fan out the work by region
+	byRegion := make(map[string]vm.List)
+	for _, m := range vms {
+		region, err := zoneToRegion(m.Zone)
+		if err != nil {
+			return nil, err
+		}
+		byRegion[region] = append(byRegion[region], m)
+	}
+	return byRegion, nil
+}
+
+// zoneToRegion converts an availability zone like us-east-2a to the zone name us-east-2
+func zoneToRegion(zone string) (string, error) {
+	return zone[0 : len(zone)-1], nil
+}

--- a/vm/gce/gcloud.go
+++ b/vm/gce/gcloud.go
@@ -3,6 +3,7 @@ package gce
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"math"
 	"os"
 	"os/exec"
@@ -21,8 +22,13 @@ const (
 	ProviderName = "gce"
 )
 
+// init will inject the GCE provider into vm.Providers, but only if the gcloud tool is available on the local path.
 func init() {
-	vm.Providers[ProviderName] = &Provider{}
+	if _, err := exec.LookPath("gcloud"); err == nil {
+		vm.Providers[ProviderName] = &Provider{}
+	} else {
+		log.Printf("please install the gcloud CLI utilities (https://cloud.google.com/sdk/downloads)")
+	}
 }
 
 func runJSONCommand(args []string, parsed interface{}) error {
@@ -46,6 +52,7 @@ type jsonVM struct {
 	Labels            map[string]string
 	CreationTimestamp time.Time
 	NetworkInterfaces []struct {
+		Network       string
 		NetworkIP     string
 		AccessConfigs []struct {
 			Name  string
@@ -71,7 +78,7 @@ func (jsonVM *jsonVM) toVM() *vm.VM {
 	}
 
 	// Extract network information
-	var publicIP, privateIP string
+	var publicIP, privateIP, vpc string
 	if len(jsonVM.NetworkInterfaces) == 0 {
 		vmErrors = append(vmErrors, vm.ErrBadNetwork)
 	} else {
@@ -80,6 +87,7 @@ func (jsonVM *jsonVM) toVM() *vm.VM {
 			vmErrors = append(vmErrors, vm.ErrBadNetwork)
 		} else {
 			publicIP = jsonVM.NetworkInterfaces[0].AccessConfigs[0].NatIP
+			vpc = jsonVM.NetworkInterfaces[0].Network
 		}
 	}
 
@@ -89,15 +97,20 @@ func (jsonVM *jsonVM) toVM() *vm.VM {
 	zone := zones[len(zones)-1]
 
 	return &vm.VM{
-		Name:      jsonVM.Name,
-		CreatedAt: jsonVM.CreationTimestamp,
-		Errors:    vmErrors,
-		DNS:       fmt.Sprintf("%s.%s.%s", jsonVM.Name, zone, project),
-		Provider:  ProviderName,
-		Lifetime:  lifetime,
-		PrivateIP: privateIP,
-		PublicIP:  publicIP,
-		Zone:      zone,
+		Name:       jsonVM.Name,
+		CreatedAt:  jsonVM.CreationTimestamp,
+		Errors:     vmErrors,
+		DNS:        fmt.Sprintf("%s.%s.%s", jsonVM.Name, zone, project),
+		Lifetime:   lifetime,
+		PrivateIP:  privateIP,
+		Provider:   ProviderName,
+		ProviderID: jsonVM.Name,
+		PublicIP:   publicIP,
+		// N.B. gcloud uses the local username to log into instances rather
+		// than the username on the authenticated Google account.
+		RemoteUser: config.OSUser.Username,
+		VPC:        vpc,
+		Zone:       zone,
 	}
 }
 

--- a/vm/local/local.go
+++ b/vm/local/local.go
@@ -90,12 +90,16 @@ func (p *Provider) List() (ret vm.List, _ error) {
 		now := time.Now()
 		for range sc.VMs {
 			ret = append(ret, vm.VM{
-				Name:      "localhost",
-				CreatedAt: now,
-				Lifetime:  time.Hour,
-				PrivateIP: "127.0.0.1",
-				PublicIP:  "127.0.0.1",
-				Zone:      config.Local,
+				Name:       "localhost",
+				CreatedAt:  now,
+				Lifetime:   time.Hour,
+				PrivateIP:  "127.0.0.1",
+				Provider:   ProviderName,
+				ProviderID: ProviderName,
+				PublicIP:   "127.0.0.1",
+				RemoteUser: config.OSUser.Username,
+				VPC:        ProviderName,
+				Zone:       ProviderName,
 			})
 		}
 	}


### PR DESCRIPTION
This adds support for managing clusters in AWS and for creating AWS+GCE
cockroach clusters.  The basic approach for AWS is similar to GCE, however
there are some complications around needing to upload a SSH key to AWS before
creating instances.  Also, AWS requires quite a bit more configuration than
GCE; all of these parameters are managed as flags, should a user need to
override the defaults.

Misc changes:
* Add vm.VM.RemoteUser since the AWS system image uses "ubuntu"
* Add --advertise-host=vm.PublicIP to cockroach clusters running in a
  multi-placement configuration.

To create a multi-cloud cluster:

```
./roachprod create bob-xyzzy -c aws,gce -n 8
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/96)
<!-- Reviewable:end -->
