### PR TITLE
Show cloud providers in list command

### DIFF
--- a/cloud/cluster_cloud.go
+++ b/cloud/cluster_cloud.go
@@ -58,6 +58,22 @@ type CloudCluster struct {
 	VMs       vm.List
 }
 
+// Clouds returns the names of all of the various cloud providers used
+// by the VMs in the cluster.
+func (c *CloudCluster) Clouds() []string {
+	present := make(map[string]bool)
+	for _, m := range c.VMs {
+		present[m.Provider] = true
+	}
+
+	var ret []string
+	for provider := range present {
+		ret = append(ret, provider)
+	}
+	sort.Strings(ret)
+	return ret
+}
+
 func (c *CloudCluster) ExpiresAt() time.Time {
 	return c.CreatedAt.Add(c.Lifetime)
 }
@@ -76,7 +92,7 @@ func (c *CloudCluster) String() string {
 }
 
 func (c *CloudCluster) PrintDetails() {
-	fmt.Printf("%s: ", c.Name)
+	fmt.Printf("%s: %s ", c.Name, c.Clouds())
 	if !c.IsLocal() {
 		l := c.LifetimeRemaining().Round(time.Second)
 		if l <= 0 {

--- a/main.go
+++ b/main.go
@@ -385,11 +385,13 @@ it exists:
 
   ~ roachprod list
   Account: marc
-  local:      1  (-)
-  marc-test:  4  (5h34m35s)
+  local:     [local]    1  (-)
+  marc-test: [aws gce]  4  (5h34m35s)
   Syncing...
 
-The second and third columns are the number of nodes in the cluster and the
+The second column lists the cloud providers that host VMs for the cluster.
+
+The third and fourth columns are the number of nodes in the cluster and the
 time remaining before the cluster will be automatically destroyed. Note that
 local clusters do not have an expiration.
 
@@ -397,9 +399,9 @@ The --details adjusts the output format to include per-node details:
 
   ~ roachprod list --details
   Account: marc
-  local: (no expiration)
+  local [local]: (no expiration)
     localhost		127.0.0.1	127.0.0.1
-  marc-test: 5h33m57s remaining
+  marc-test: [aws gce] 5h33m57s remaining
     marc-test-0001	marc-test-0001.us-east1-b.cockroach-ephemeral	10.142.0.18	35.229.60.91
     marc-test-0002	marc-test-0002.us-east1-b.cockroach-ephemeral	10.142.0.17	35.231.0.44
     marc-test-0003	marc-test-0003.us-east1-b.cockroach-ephemeral	10.142.0.19	35.229.111.100
@@ -462,7 +464,7 @@ hosts file.
 			if listDetails {
 				c.PrintDetails()
 			} else {
-				fmt.Fprintf(tw, "%s:\t%d", c.Name, len(c.VMs))
+				fmt.Fprintf(tw, "%s:\t%s\t%d", c.Name, c.Clouds(), len(c.VMs))
 				if !c.IsLocal() {
 					fmt.Fprintf(tw, "\t(%s)", c.LifetimeRemaining().Round(time.Second))
 				} else {


### PR DESCRIPTION
This change updates the list command to make it easy to determine which cloud
providers are hosting the VMs that comprise a cluster.

Resolves #103

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/106)
<!-- Reviewable:end -->
