### PR TITLE
Add local-ssd support to AWS

### DIFF
--- a/vm/aws/support.go
+++ b/vm/aws/support.go
@@ -10,16 +10,32 @@ import (
 	"github.com/pkg/errors"
 )
 
-// We're using an M5 type machine, which exposes EBS volumes as though they were locally-attached NVMe
-// block devices.  This user-data script will create a filesystem, mount the data volume, and chown it to
-// the ubuntu user which will be running the cockroach binary.
+// Both M5 and I3 machines expose their EBS or local SSD volumes as NVMe block devices, but
+// the actual device numbers vary a bit between the two types.
+// This user-data script will create a filesystem, mount the data volume, and chmod 777.
 // https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html
 const awsStartupScript = `#!/usr/bin/env bash
-set -e
-mkfs.ext4 /dev/nvme1n1
-mkdir -p /mnt/data1
-mount /dev/nvme1n1 /mnt/data1
-chown -R ubuntu:ubuntu /mnt/data1
+set -x
+disknum=0
+for d in $(ls /dev/nvme?n1); do
+  if ! mount | grep ${d}; then
+    let "disknum++"
+    echo "Disk ${d} not mounted, creating..."
+    mountpoint="/mnt/data${disknum}"
+    mkdir -p "${mountpoint}"
+    mkfs.ext4 ${d}
+    mount -o discard,defaults ${d} ${mountpoint}
+    chmod 777 ${mountpoint}
+    echo "${d} ${mountpoint} ext4 discard,defaults 1 1" | tee -a /etc/fstab
+  else
+    echo "Disk ${disknum}: ${d} already mounted, skipping..."
+  fi
+done
+if [ "${disknum}" -eq "0" ]; then
+  echo "No disks mounted, creating /mnt/data1"
+  mkdir -p /mnt/data1
+  chmod 777 /mnt/data1
+fi
 `
 
 // runCommand is used to invoke an AWS command for which no output is expected.


### PR DESCRIPTION
This change supports mounting local SSD volumes in AWS by selecting an
i-class machine type, which has locally-attached storage.  The startup script
is generalized to support both EBS- and SSD-based setups.

Resolves #104

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/107)
<!-- Reviewable:end -->
