### PR TITLE
Fix `status` on linux boxes

### DIFF
--- a/install/cluster_synced.go
+++ b/install/cluster_synced.go
@@ -166,7 +166,7 @@ func (c *SyncedCluster) Status() {
 
 		binary := cockroachNodeBinary(c, c.Nodes[i])
 		cmd := fmt.Sprintf(
-			"out=$(ps axeww -o ucomm -o pid -o command | awk '/ROACHPROD=(%d)/ {print $1, $2}'",
+			"out=$(ps axeww -o pid -o ucomm -o command | awk '/ROACHPROD=(%d)/ {print $2, $1}'",
 			c.Nodes[i])
 		cmd += ` | sort | uniq);
 vers=$(` + binary + ` version 2>/dev/null | awk '/Build Tag:/ {print $NF}')


### PR DESCRIPTION
The `status` command was not displaying the process pid because `ps -o
ucomm` differs between OS X and Linux. Restructured that `status` shell
pipeline to avoid the discrepancy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/111)
<!-- Reviewable:end -->
