### PR TITLE
ssh: permit multi-node ssh with iterm2 splits

### DIFF
--- a/install/cluster_synced.go
+++ b/install/cluster_synced.go
@@ -708,8 +708,13 @@ func (c *SyncedCluster) pgurls(nodes []int) map[int]string {
 }
 
 func (c *SyncedCluster) Ssh(sshArgs, args []string) error {
-	if len(c.Nodes) != 1 {
-		return fmt.Errorf("invalid number of nodes for ssh: %d", len(c.Nodes))
+	if len(c.Nodes) != 1 && len(args) == 0 {
+		// If trying to ssh to more than 1 node and the ssh session is interative,
+		// try sshing with an iTerm2 split screen configuration.
+		sshed, err := maybeSplitScreenSSHITerm2(c)
+		if sshed {
+			return err
+		}
 	}
 
 	allArgs := []string{

--- a/install/iterm2.go
+++ b/install/iterm2.go
@@ -1,0 +1,69 @@
+package install
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+)
+
+const splitScript = `
+ if (path to frontmost application as text) does not contain "iTerm" then
+        return "Can't multi-ssh without iTerm 2 as the active terminal."
+ end if
+ tell application "iTerm2"
+        activate
+        tell (create window with default profile)
+            set pane_count to %d
+            set col_count to round ((pane_count) ^ 0.5) rounding up
+            set row_count to round ((pane_count) / col_count) rounding up
+            repeat row_count - 1 times
+                tell current session
+                    split horizontally with default profile
+                end tell
+            end repeat
+            set cur to row_count
+            repeat row_count times
+                repeat col_count - 1 times
+                    if cur is equal to (pane_count) then
+                        exit repeat
+                    end if
+                    tell current session
+                        split vertically with default profile
+                    end tell
+                    set cur to cur + 1
+                end repeat
+                tell application "System Events" to tell process "iTerm2" to click menu item "Select Pane Below" of menu 1 of menu item "Select Split Pane" of menu 1 of menu bar item "Window" of menu bar 1
+            end repeat
+            tell current tab
+                set node_list to {%s}
+                repeat with i from 1 to pane_count
+                    tell item i of sessions to write text "roachprod ssh %s:" & item i of node_list
+                end repeat
+            end tell
+        end tell
+    end tell
+return`
+
+// maybeSplitScreenSSHITerm2 sshs to all of the specified nodes in the
+// SyncedCluster in an iTerm2 split-screen configuration if possible. It
+// returns true in the first position if it went through with the split-screen
+// ssh.
+func maybeSplitScreenSSHITerm2(c *SyncedCluster) (bool, error) {
+	osascriptPath, err := exec.LookPath("osascript")
+	if err != nil {
+		return false, err
+	}
+	nodeStrings := make([]string, len(c.Nodes))
+	for i, nodeID := range c.Nodes {
+		nodeStrings[i] = fmt.Sprint(nodeID)
+	}
+	script := fmt.Sprintf(splitScript, len(c.Nodes), strings.Join(nodeStrings, ","), c.Name)
+	allArgs := []string{
+		"osascript",
+		"-e",
+		script,
+	}
+	return true, syscall.Exec(osascriptPath, allArgs, os.Environ())
+}


### PR DESCRIPTION
This commit uses some AppleScript and iTerm2 magic to automatically pop
open a window with one split per node, and re-invoke roachprod ssh in
all of them. This allows you to have an ssh connection open to all of
the nodes in a roachprod cluster at once.

Then, you can use iTerm2's type-to-all-panes feature to interact with
all of the nodes at once (Shell->Broadcast Input->Broadcast Input to All
Panes in Current Tab, or Cmd-Ctrl-I).

Here's a gif of what it looks like:

https://gfycat.com/gifs/detail/LightheartedFavoriteFurseal

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/112)
<!-- Reviewable:end -->
