### PR TITLE
Force aws output to json

### DIFF
--- a/vm/aws/support.go
+++ b/vm/aws/support.go
@@ -54,6 +54,8 @@ func runCommand(args []string) error {
 
 // runJSONCommand invokes an aws command and parses the json output.
 func runJSONCommand(args []string, parsed interface{}) error {
+	// force json output in case the user has overridden the default behavior
+	args = append(args[:len(args):len(args)], "--output", "json")
 	cmd := exec.Command("aws", args...)
 
 	rawJSON, err := cmd.Output()


### PR DESCRIPTION
It's possible for a user to configure their local environment such that the aws
tool will output in textual or tabular formats.  This change always sets the
--output option to json.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/114)
<!-- Reviewable:end -->
