### PR TITLE
Don't bail out if ssh-keygen -R fails

### DIFF
--- a/main.go
+++ b/main.go
@@ -275,7 +275,6 @@ Local Clusters
 					out, err := cmd.CombinedOutput()
 					if err != nil {
 						log.Printf("could not clear ssh key for hostname %s:\n%s", v.PublicIP, string(out))
-						return err
 					}
 				}
 


### PR DESCRIPTION
If ~/.ssh doesn't exist, like in the TeamCity nightly test, `ssh-keygen
-R` will fail with "mkstemp: no such directory". This doesn't seem worth
bailing out for. Instead, just print the warning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/116)
<!-- Reviewable:end -->
