### PR TITLE
Add error message on 404 on `roachprod put local`

### DIFF
--- a/install/cluster_synced.go
+++ b/install/cluster_synced.go
@@ -465,6 +465,10 @@ func (c *SyncedCluster) Put(src, dest string) {
 			defer wg.Done()
 
 			if c.IsLocal() {
+				if _, err := os.Stat(src); err != nil {
+					results <- result{i, err}
+					return
+				}
 				from, err := filepath.Abs(src)
 				if err != nil {
 					results <- result{i, err}


### PR DESCRIPTION
When `roachprod put local` is run no error is shown when trying to put a
file that does not exist because it is not copying the file, but trying
to make a symlink.

Instead of failing silently, now `roachprod put` will inform the user
that nothing was copied if the file doesn't exist.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/119)
<!-- Reviewable:end -->
