### PR TITLE
Add --racks flag to "start" command

### DIFF
--- a/main.go
+++ b/main.go
@@ -52,6 +52,7 @@ destroy the cluster.
 
 var (
 	numNodes       int
+	numRacks       int
 	username       string
 	dryrun         bool
 	extendLifetime time.Duration
@@ -106,6 +107,15 @@ Hint: use "roachprod sync" to update the list of available clusters.
 	switch clusterType {
 	case "cockroach":
 		c.Impl = install.Cockroach{}
+		if numRacks > 0 {
+			for i := range c.Localities {
+				rack := fmt.Sprintf("rack=%d", i%numRacks)
+				if c.Localities[i] != "" {
+					rack = "," + rack
+				}
+				c.Localities[i] += rack
+			}
+		}
 	case "cassandra":
 		c.Impl = install.Cassandra{}
 	default:
@@ -1074,6 +1084,9 @@ func main() {
 
 	sshCmd.Flags().BoolVar(
 		&secure, "secure", false, "use a secure cluster")
+
+	startCmd.Flags().IntVarP(&numRacks,
+		"racks", "r", 0, "the number of racks to partition the nodes into")
 
 	testCmd.Flags().DurationVarP(
 		&duration, "duration", "d", 5*time.Minute, "the duration to run each test")


### PR DESCRIPTION
Allow the specification of a `rack=` locality by specifying the
`--racks=<count>` flag. Assignment of nodes to racks is deterministic
based on node index. To be used for experimentation with partitioning in
single datacenter clusters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/120)
<!-- Reviewable:end -->
