### PR TITLE
Add tagging facility to start, status, stop and ssh

### DIFF
--- a/install/cluster_synced.go
+++ b/install/cluster_synced.go
@@ -48,6 +48,7 @@ type SyncedCluster struct {
 	Secure  bool
 	Env     string
 	Args    []string
+	Tag     string
 	Impl    ClusterImpl
 }
 
@@ -124,8 +125,8 @@ func (c *SyncedCluster) Stop() {
 		// NB: the awkward-looking `awk` invocation serves to avoid having the
 		// awk process match its own output from `ps`.
 		cmd := fmt.Sprintf(
-			"ps axeww -o pid -o command | awk '/ROACHPROD=(true|%d)/ { print $1 }' | xargs kill -9 || true;",
-			c.Nodes[i])
+			"ps axeww -o pid -o command | awk '/ROACHPROD=(%d%s)[ \\/]/ { print $1 }' | xargs kill -9 || true;",
+			c.Nodes[i], c.escapedTag())
 		return session.CombinedOutput(cmd)
 	})
 }
@@ -169,8 +170,8 @@ func (c *SyncedCluster) Status() {
 
 		binary := cockroachNodeBinary(c, c.Nodes[i])
 		cmd := fmt.Sprintf(
-			"out=$(ps axeww -o pid -o ucomm -o command | awk '/ROACHPROD=(%d)/ {print $2, $1}'",
-			c.Nodes[i])
+			"out=$(ps axeww -o pid -o ucomm -o command | awk '/ROACHPROD=(%d%s)[ \\/]/ {print $2, $1}'",
+			c.Nodes[i], c.escapedTag())
 		cmd += ` | sort | uniq);
 vers=$(` + binary + ` version 2>/dev/null | awk '/Build Tag:/ {print $NF}')
 if [ -n "${out}" -a -n "${vers}" ]; then
@@ -294,7 +295,7 @@ func (c *SyncedCluster) Run(w io.Writer, nodes []int, title, cmd string) error {
 		}
 		defer session.Close()
 
-		nodeCmd := fmt.Sprintf("export ROACHPROD=%d && ", nodes[i]) + cmd
+		nodeCmd := fmt.Sprintf("export ROACHPROD=%d%s && ", nodes[i], c.Tag) + cmd
 		if c.IsLocal() {
 			nodeCmd = fmt.Sprintf("cd ${HOME}/local/%d ; %s", nodes[i], cmd)
 		}
@@ -433,7 +434,7 @@ func (c *SyncedCluster) RunLoad(cmd string, stdout, stderr io.Writer) error {
 	for i, ip := range ips {
 		urls = append(urls, c.Impl.NodeURL(c, ip, c.Impl.NodePort(c, nodes[i])))
 	}
-	prefix := fmt.Sprintf("ulimit -n 16384; export ROACHPROD=%d && ", c.LoadGen)
+	prefix := fmt.Sprintf("ulimit -n 16384; export ROACHPROD=%d%s && ", c.LoadGen, c.Tag)
 	return session.Run(prefix + cmd + " " + strings.Join(urls, " "))
 }
 
@@ -703,7 +704,7 @@ func (c *SyncedCluster) Ssh(sshArgs, args []string) error {
 	}
 	allArgs = append(allArgs, sshArgs...)
 	if len(args) > 0 {
-		allArgs = append(allArgs, fmt.Sprintf("export ROACHPROD=%d ;", c.Nodes[0]))
+		allArgs = append(allArgs, fmt.Sprintf("export ROACHPROD=%d%s ;", c.Nodes[0], c.Tag))
 	}
 	if c.IsLocal() {
 		allArgs = append(allArgs, fmt.Sprintf("cd ${HOME}/local/%d ; ", c.Nodes[0]))
@@ -846,4 +847,8 @@ func (c *SyncedCluster) Parallel(display string, count, concurrency int, fn func
 		}
 		log.Fatal("command failed")
 	}
+}
+
+func (c *SyncedCluster) escapedTag() string {
+	return strings.Replace(c.Tag, "/", "\\/", -1)
 }

--- a/install/cockroach.go
+++ b/install/cockroach.go
@@ -318,7 +318,7 @@ tar cvf certs.tar certs
 		// unhelpful empty error (since everything has been redirected away). This is
 		// unfortunately equally awkward to address.
 		cmd := "mkdir -p " + logDir + "; " +
-			fmt.Sprintf(" export ROACHPROD=%d && ", nodes[i]) +
+			fmt.Sprintf(" export ROACHPROD=%d%s && ", nodes[i], c.Tag) +
 			c.Env + " " + binary + " start " + strings.Join(args, " ") +
 			" >> " + logDir + "/cockroach.stdout 2>> " + logDir + "/cockroach.stderr" +
 			" || (x=$?; cat " + logDir + "/cockroach.stderr; exit $x)"


### PR DESCRIPTION
Add a `--tag` flag to the `start`, `status`, `stop` and `ssh` command
that allows for the selection of a process by tag. Specifying
`--tag=foo` to `start` or `ssh` allows restricting subsequent `status`
and `stop` commands to only processes matching the tag. If a tag isn't
specified, `status` and `stop` will matching all processes started by
`roachprod`.

Fixes #123

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/124)
<!-- Reviewable:end -->
