### PR TITLE
Fix stopping/status of local clusters

### DIFF
--- a/install/cluster_synced.go
+++ b/install/cluster_synced.go
@@ -124,8 +124,9 @@ func (c *SyncedCluster) Stop() {
 		// NB: xargs --no-run-if-empty is not supported on OSX.
 		// NB: the awkward-looking `awk` invocation serves to avoid having the
 		// awk process match its own output from `ps`.
-		cmd := fmt.Sprintf(
-			"ps axeww -o pid -o command | awk '/ROACHPROD=(%d%s)[ \\/]/ { print $1 }' | xargs kill -9 || true;",
+		cmd := fmt.Sprintf(`ps axeww -o pid -o command | \
+  sed 's/export ROACHPROD=//g' | \
+  awk '/ROACHPROD=(%d%s)[ \/]/ { print $1 }' | xargs kill -9 || true;`,
 			c.Nodes[i], c.escapedTag())
 		return session.CombinedOutput(cmd)
 	})
@@ -169,8 +170,9 @@ func (c *SyncedCluster) Status() {
 		defer session.Close()
 
 		binary := cockroachNodeBinary(c, c.Nodes[i])
-		cmd := fmt.Sprintf(
-			"out=$(ps axeww -o pid -o ucomm -o command | awk '/ROACHPROD=(%d%s)[ \\/]/ {print $2, $1}'",
+		cmd := fmt.Sprintf(`out=$(ps axeww -o pid -o ucomm -o command | \
+  sed 's/export ROACHPROD=//g' | \
+  awk '/ROACHPROD=(%d%s)[ \/]/ {print $2, $1}'`,
 			c.Nodes[i], c.escapedTag())
 		cmd += ` | sort | uniq);
 vers=$(` + binary + ` version 2>/dev/null | awk '/Build Tag:/ {print $NF}')


### PR DESCRIPTION
Strip out `export ROACHPROD=` from the `ps` output so that we don't
accidentally match remote ssh commands when running `status` or `stop`
on a local cluster. This was causing `roachprod stop local` to kill
remote roachprod ssh connections.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/132)
<!-- Reviewable:end -->
