### PR TITLE
Don't log status line for internal pgurl

### DIFF
--- a/main.go
+++ b/main.go
@@ -1005,8 +1005,7 @@ var pgurlCmd = &cobra.Command{
 				ips[i] = c.VMs[nodes[i]-1]
 			}
 		} else {
-			display := fmt.Sprintf("%s: retrieving IP addresses", c.Name)
-			c.Parallel(display, len(nodes), 0, func(i int) ([]byte, error) {
+			c.Parallel("", len(nodes), 0, func(i int) ([]byte, error) {
 				var err error
 				ips[i], err = c.GetInternalIP(nodes[i])
 				return nil, err


### PR DESCRIPTION
This makes the output harder to parse and is also inconsistent
with `pgurl --external`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/135)
<!-- Reviewable:end -->
