### PR TITLE
run: use the expander in roachprod run

### DIFF
--- a/install/cluster_synced.go
+++ b/install/cluster_synced.go
@@ -297,6 +297,9 @@ func (c *SyncedCluster) Run(w io.Writer, nodes []int, title, cmd string) error {
 		}
 		defer session.Close()
 
+		var e expander
+		cmd = e.expand(c, cmd)
+
 		nodeCmd := fmt.Sprintf("export ROACHPROD=%d%s && ", nodes[i], c.Tag) + cmd
 		if c.IsLocal() {
 			nodeCmd = fmt.Sprintf("cd ${HOME}/local/%d ; %s", nodes[i], cmd)


### PR DESCRIPTION
The run and ssh commands were not as interchangeable as I had believed
when writing cockroachdb/cockroach#24322

Addresses part of #138

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/139)
<!-- Reviewable:end -->
