### PR TITLE
Make the GCE project configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## roachprod
 
-⚠️ roachprod is an **internal** tool for testing CockroachDB clusters. Use at
-your own risk! ⚠️
+⚠️ roachprod is an **internal** tool for creating and testing
+CockroachDB clusters. Use at your own risk! ⚠️
 
 ## Setup
 
@@ -17,13 +17,19 @@ $ go get -u github.com/cockroachdb/roachprod
 
 ## Summary
 
-* Clusters are created under the [cockroach-ephemeral] GCE project.
-* Anyone can connect to any port on VMs in `cockroach-ephemeral`.
+* By default, clusters are created in the [cockroach-ephemeral] GCE
+  project. Use the `--gce-project` flag or `GCE_PROJECT` environment
+  variable to create clusters in a different GCE project. Note that
+  the `lifetime` functionality requires `roachprod gc
+  --gce-project=<name>` to be run periodically (i.e. via a
+  cronjob). This is only provided out-of-the-box for the
+  [cockroach-ephemeral] cluster.
+* Anyone can connect to any port on VMs in [cockroach-ephemeral].
   **DO NOT STORE SENSITIVE DATA**.
 * Cluster names are prefixed with the user creating them. For example,
   `roachprod create test` creates the `marc-test` cluster.
-* VMs have a default lifetime of 12 hours (changeable with the `-l` flag) and
-  are deleted 6 hours after expiration.
+* VMs have a default lifetime of 12 hours (changeable with the
+  `--lifetime` flag).
 * Default settings create 4 VMs (`-n 4`) with 4 CPUs, 15GB memory
   (`--machine-type=n1-standard-4`), and local SSDs (`--local-ssd`).
 

--- a/main.go
+++ b/main.go
@@ -1134,6 +1134,12 @@ func main() {
 	// Allow each Provider to inject additional configuration flags
 	for _, p := range vm.Providers {
 		p.Flags().ConfigureCreateFlags(createCmd.Flags())
+
+		for _, cmd := range []*cobra.Command{
+			createCmd, destroyCmd, extendCmd, listCmd, syncCmd, gcCmd,
+		} {
+			p.Flags().ConfigureClusterFlags(cmd.Flags())
+		}
 	}
 
 	extendCmd.Flags().DurationVarP(&extendLifetime,

--- a/vm/aws/aws.go
+++ b/vm/aws/aws.go
@@ -88,6 +88,9 @@ func (o *providerOpts) ConfigureCreateFlags(flags *pflag.FlagSet) {
 		"ubuntu", "Name of the remote user to SSH as")
 }
 
+func (o *providerOpts) ConfigureClusterFlags(flags *pflag.FlagSet) {
+}
+
 // Provider implements the vm.Provider interface for AWS.
 type Provider struct {
 	opts providerOpts

--- a/vm/local/local.go
+++ b/vm/local/local.go
@@ -31,6 +31,10 @@ type emptyFlags struct{}
 func (o *emptyFlags) ConfigureCreateFlags(flags *pflag.FlagSet) {
 }
 
+// ConfigureClusterFlags is part of ProviderFlags.  This implementation is a no-op.
+func (o *emptyFlags) ConfigureClusterFlags(*pflag.FlagSet) {
+}
+
 // CleanSSH is part of the vm.Provider interface.  This implementation is a no-op.
 func (p *Provider) CleanSSH() error {
 	return nil

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -116,8 +116,11 @@ type CreateOpts struct {
 // If a new command is added (perhaps `roachprod enlarge`) that needs additional provider-
 // specific flags, add a similarly-named method `ConfigureEnlargeFlags` to mix in the additional flags.
 type ProviderFlags interface {
-	// Configures a FlagSet with any options relevant to the `roachprod create` command
+	// Configures a FlagSet with any options relevant to the `create` command.
 	ConfigureCreateFlags(*pflag.FlagSet)
+	// Configures a FlagSet with any options relevant to cluster manipulation
+	// commands (`create`, `destroy`, `list`, `sync` and `gc`).
+	ConfigureClusterFlags(*pflag.FlagSet)
 }
 
 // A Provider is a source of virtual machines running on some hosting platform.


### PR DESCRIPTION
Add a `--gce-project` flag to the `create`, `destroy`, `list`, `sync`
and `gc` flags. Defaults to the `GCE_PROJECT` env var, or
`cockroach-ephemeral` if that env var is empty (or unset).

Fixes #136

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/143)
<!-- Reviewable:end -->
