### PR TITLE
Fix node-specific template expansion for `start` and `run`

### DIFF
--- a/install/cockroach.go
+++ b/install/cockroach.go
@@ -311,7 +311,15 @@ tar cvf certs.tar certs
 		if advertisePublicIP {
 			args = append(args, fmt.Sprintf("--advertise-host=%s", host))
 		}
-		args = append(args, extraArgs...)
+
+		// Argument template expansion is node specific (e.g. for {store-dir}).
+		e := expander{
+			node: nodes[i],
+		}
+		for _, arg := range extraArgs {
+			arg = e.expand(c, arg)
+			args = append(args, strings.Split(arg, " ")...)
+		}
 
 		binary := cockroachNodeBinary(c, nodes[i])
 		// NB: this is awkward as when the process fails, the test runner will show an

--- a/install/expander.go
+++ b/install/expander.go
@@ -12,6 +12,7 @@ var pgPortRe = regexp.MustCompile(`{pgport(:[-,0-9]+)?}`)
 var storeDirRe = regexp.MustCompile(`{store-dir}`)
 
 type expander struct {
+	node    int
 	pgURLs  map[int]string
 	pgPorts map[int]string
 }
@@ -70,7 +71,7 @@ func (e *expander) maybeExpandStoreDir(c *SyncedCluster, s string) (string, bool
 	if !storeDirRe.MatchString(s) {
 		return s, false
 	}
-	return c.Impl.NodeDir(c, c.Nodes[0]), true
+	return c.Impl.NodeDir(c, e.node), true
 }
 
 func (e *expander) expand(c *SyncedCluster, arg string) string {


### PR DESCRIPTION
Argument template expansion is not specified (e.g. for
`{store-dir}`). Fix expansion for `start` and `run` to be performed
per-node.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/144)
<!-- Reviewable:end -->
