### PR TITLE
Remove the use of ssh for "local" clusters

### DIFF
--- a/install/cluster_synced.go
+++ b/install/cluster_synced.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/roachprod/config"
 	"github.com/cockroachdb/roachprod/ssh"
 	"github.com/cockroachdb/roachprod/ui"
+
 	"github.com/pkg/errors"
 )
 
@@ -107,10 +108,22 @@ func (c *SyncedCluster) Start() {
 	c.Impl.Start(c, c.Args)
 }
 
+func (c *SyncedCluster) newSession(i int) (session, error) {
+	if c.IsLocal() {
+		return newLocalSession(), nil
+	}
+
+	s, err := ssh.NewSSHSession(c.user(i), c.host(i))
+	if err != nil {
+		return nil, err
+	}
+	return &remoteSession{s}, nil
+}
+
 func (c *SyncedCluster) Stop() {
 	display := fmt.Sprintf("%s: stopping", c.Name)
 	c.Parallel(display, len(c.Nodes), 0, func(i int) ([]byte, error) {
-		session, err := ssh.NewSSHSession(c.user(c.Nodes[i]), c.host(c.Nodes[i]))
+		session, err := c.newSession(c.Nodes[i])
 		if err != nil {
 			return nil, err
 		}
@@ -130,7 +143,7 @@ func (c *SyncedCluster) Wipe() {
 	display := fmt.Sprintf("%s: wiping", c.Name)
 	c.Stop()
 	c.Parallel(display, len(c.Nodes), 0, func(i int) ([]byte, error) {
-		session, err := ssh.NewSSHSession(c.user(c.Nodes[i]), c.host(c.Nodes[i]))
+		session, err := c.newSession(c.Nodes[i])
 		if err != nil {
 			return nil, err
 		}
@@ -156,7 +169,7 @@ func (c *SyncedCluster) Status() {
 	display := fmt.Sprintf("%s: status", c.Name)
 	results := make([]string, len(c.Nodes))
 	c.Parallel(display, len(c.Nodes), 0, func(i int) ([]byte, error) {
-		session, err := ssh.NewSSHSession(c.user(c.Nodes[i]), c.host(c.Nodes[i]))
+		session, err := c.newSession(c.Nodes[i])
 		if err != nil {
 			results[i] = err.Error()
 			return nil, nil
@@ -205,19 +218,20 @@ func (c *SyncedCluster) Monitor() chan nodeMonitorInfo {
 
 	for i := range nodes {
 		go func(i int) {
-			session, err := ssh.NewSSHSession(c.user(nodes[i]), c.host(nodes[i]))
+			session, err := c.newSession(nodes[i])
 			if err != nil {
 				ch <- nodeMonitorInfo{nodes[i], err.Error()}
 				return
 			}
 			defer session.Close()
 
-			go func() {
-				p, err := session.StdoutPipe()
-				if err != nil {
-					ch <- nodeMonitorInfo{nodes[i], err.Error()}
-					return
-				}
+			p, err := session.StdoutPipe()
+			if err != nil {
+				ch <- nodeMonitorInfo{nodes[i], err.Error()}
+				return
+			}
+
+			go func(p io.Reader) {
 				r := bufio.NewReader(p)
 				for {
 					line, _, err := r.ReadLine()
@@ -226,7 +240,7 @@ func (c *SyncedCluster) Monitor() chan nodeMonitorInfo {
 					}
 					ch <- nodeMonitorInfo{nodes[i], string(line)}
 				}
-			}()
+			}(p)
 
 			// On each monitored node, we loop looking for a cockroach process. In
 			// order to avoid polling with lsof, if we find a live process we use nc
@@ -257,7 +271,7 @@ done
 
 			// Request a PTY so that the script will receive will receive a SIGPIPE
 			// when the session is closed.
-			if err := session.RequestPty("vt100", 40, 80, nil); err != nil {
+			if err := session.RequestPty(); err != nil {
 				ch <- nodeMonitorInfo{nodes[i], err.Error()}
 				return
 			}
@@ -289,7 +303,7 @@ func (c *SyncedCluster) Run(w io.Writer, nodes []int, title, cmd string) error {
 	errors := make([]error, len(nodes))
 	results := make([]string, len(nodes))
 	c.Parallel(display, len(nodes), 0, func(i int) ([]byte, error) {
-		session, err := ssh.NewSSHSession(c.user(nodes[i]), c.host(nodes[i]))
+		session, err := c.newSession(nodes[i])
 		if err != nil {
 			errors[i] = err
 			results[i] = err.Error()
@@ -309,7 +323,8 @@ func (c *SyncedCluster) Run(w io.Writer, nodes []int, title, cmd string) error {
 		}
 
 		if stream {
-			session.Stdout = w
+			session.SetStdout(w)
+			session.SetStderr(w)
 			errors[i] = session.Run(nodeCmd)
 			return nil, nil
 		}
@@ -343,7 +358,7 @@ func (c *SyncedCluster) Wait() error {
 	errs := make([]error, len(c.Nodes))
 	c.Parallel(display, len(c.Nodes), 0, func(i int) ([]byte, error) {
 		for j := 0; j < 600; j++ {
-			session, err := ssh.NewSSHSession(c.user(c.Nodes[i]), c.host(c.Nodes[i]))
+			session, err := c.newSession(c.Nodes[i])
 			if err != nil {
 				time.Sleep(500 * time.Millisecond)
 				continue
@@ -386,7 +401,7 @@ func (c *SyncedCluster) CockroachVersions() map[string]int {
 	display := fmt.Sprintf("%s: cockroach version", c.Name)
 	nodes := c.ServerNodes()
 	c.Parallel(display, len(nodes), 0, func(i int) ([]byte, error) {
-		session, err := ssh.NewSSHSession(c.user(c.Nodes[i]), c.host(nodes[i]))
+		session, err := c.newSession(c.Nodes[i])
 		if err != nil {
 			return nil, err
 		}
@@ -817,7 +832,7 @@ func (c *SyncedCluster) stopLoad() {
 
 	display := fmt.Sprintf("%s: stopping load", c.Name)
 	c.Parallel(display, 1, 0, func(i int) ([]byte, error) {
-		session, err := ssh.NewSSHSession(c.user(c.LoadGen), c.host(c.LoadGen))
+		session, err := c.newSession(c.LoadGen)
 		if err != nil {
 			return nil, err
 		}

--- a/install/session.go
+++ b/install/session.go
@@ -1,0 +1,98 @@
+package install
+
+import (
+	"context"
+	"io"
+	"os/exec"
+
+	gossh "golang.org/x/crypto/ssh"
+)
+
+type session interface {
+	CombinedOutput(cmd string) ([]byte, error)
+	Run(cmd string) error
+	SetStdin(r io.Reader)
+	SetStdout(w io.Writer)
+	SetStderr(w io.Writer)
+	StdinPipe() (io.WriteCloser, error)
+	StdoutPipe() (io.Reader, error)
+	StderrPipe() (io.Reader, error)
+	RequestPty() error
+	Close() error
+}
+
+type remoteSession struct {
+	*gossh.Session
+}
+
+func (s *remoteSession) SetStdin(r io.Reader) {
+	s.Stdin = r
+}
+
+func (s *remoteSession) SetStdout(w io.Writer) {
+	s.Stdout = w
+}
+
+func (s *remoteSession) SetStderr(w io.Writer) {
+	s.Stderr = w
+}
+
+func (s *remoteSession) RequestPty() error {
+	return s.Session.RequestPty("vt100", 40, 80, nil)
+}
+
+type localSession struct {
+	*exec.Cmd
+	cancel func()
+}
+
+func newLocalSession() *localSession {
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := exec.CommandContext(ctx, "/bin/bash", "-c")
+	return &localSession{cmd, cancel}
+}
+
+func (s *localSession) CombinedOutput(cmd string) ([]byte, error) {
+	s.Cmd.Args = append(s.Cmd.Args, cmd)
+	return s.Cmd.CombinedOutput()
+}
+
+func (s *localSession) Run(cmd string) error {
+	s.Cmd.Args = append(s.Cmd.Args, cmd)
+	return s.Cmd.Run()
+}
+
+func (s *localSession) SetStdin(r io.Reader) {
+	s.Stdin = r
+}
+
+func (s *localSession) SetStdout(w io.Writer) {
+	s.Stdout = w
+}
+
+func (s *localSession) SetStderr(w io.Writer) {
+	s.Stderr = w
+}
+
+func (s *localSession) StdoutPipe() (io.Reader, error) {
+	// NB: exec.Cmd.StdoutPipe returns a io.ReadCloser, hence the need for the
+	// temporary storage into local variables.
+	r, err := s.Cmd.StdoutPipe()
+	return r, err
+}
+
+func (s *localSession) StderrPipe() (io.Reader, error) {
+	// NB: exec.Cmd.StderrPipe returns a io.ReadCloser, hence the need for the
+	// temporary storage into local variables.
+	r, err := s.Cmd.StderrPipe()
+	return r, err
+}
+
+func (s *localSession) RequestPty() error {
+	return nil
+}
+
+func (s *localSession) Close() error {
+	s.cancel()
+	return nil
+}

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -171,18 +171,18 @@ func IsSigKill(err error) bool {
 	return false
 }
 
-type progressWriter struct {
-	writer   io.Writer
-	done     int64
-	total    int64
-	progress func(float64)
+type ProgressWriter struct {
+	Writer   io.Writer
+	Done     int64
+	Total    int64
+	Progress func(float64)
 }
 
-func (p *progressWriter) Write(b []byte) (int, error) {
-	n, err := p.writer.Write(b)
+func (p *ProgressWriter) Write(b []byte) (int, error) {
+	n, err := p.Writer.Write(b)
 	if err == nil {
-		p.done += int64(n)
-		p.progress(float64(p.done) / float64(p.total))
+		p.Done += int64(n)
+		p.Progress(float64(p.Done) / float64(p.Total))
 	}
 	return n, err
 }
@@ -207,7 +207,7 @@ func SCPPut(src, dest string, progress func(float64), session *ssh.Session) erro
 		}
 		defer w.Close()
 		fmt.Fprintf(w, "C%#o %d %s\n", s.Mode().Perm(), s.Size(), path.Base(src))
-		p := &progressWriter{w, 0, s.Size(), progress}
+		p := &ProgressWriter{w, 0, s.Size(), progress}
 		if _, err := io.Copy(p, f); err != nil {
 			errCh <- err
 			return
@@ -295,7 +295,7 @@ func SCPGet(src, dest string, progress func(float64), session *ssh.Session) erro
 
 				fmt.Fprint(wp, "\x00")
 
-				p := &progressWriter{f, 0, size, progress}
+				p := &ProgressWriter{f, 0, size, progress}
 				if _, err := io.Copy(p, io.LimitReader(r, size)); err != nil {
 					errCh <- err
 					return

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -132,6 +132,10 @@ var sshState = struct {
 }
 
 func NewSSHSession(user, host string) (*ssh.Session, error) {
+	if host == "127.0.0.1" || host == "localhost" {
+		return nil, errors.New("unable to ssh to localhost; file a bug")
+	}
+
 	sshState.clientMu.Lock()
 	target := fmt.Sprintf("%s@%s", user, host)
 	client := sshState.clients[target]
@@ -153,10 +157,6 @@ func NewSSHSession(user, host string) (*ssh.Session, error) {
 		var err error
 		client.Client, _, err = newSSHClient(user, host)
 		if err != nil {
-			if host == "127.0.0.1" || host == "localhost" {
-				err = errors.Wrap(err, "could not ssh to localhost: "+
-					"ensure that you have password-less sshd set up")
-			}
 			return nil, err
 		}
 	}


### PR DESCRIPTION
Add `session` interface and `{local,remote}Session` implementations. The
`localSession` is a small wrapper around `exec.Cmd` while the remote
session is a small wrapper around `ssh.Session`. Commands executed with
`localSession` are always run via `/bin/bash -c` which has the nice
side-effect of removing any dependency on the users shell.

Fixes #128

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/146)
<!-- Reviewable:end -->
