### PR TITLE
Fix binary flag default value

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	Binary     = "./cockroach"
+	Binary     = "cockroach"
 	SlackToken string
 	OSUser     *user.User
 )

--- a/main.go
+++ b/main.go
@@ -1182,7 +1182,7 @@ func main() {
 		switch cmd {
 		case startCmd, testCmd:
 			cmd.Flags().StringVarP(
-				&config.Binary, "binary", "b", "./cockroach",
+				&config.Binary, "binary", "b", config.Binary,
 				"the remote cockroach binary used to start a server")
 			cmd.Flags().BoolVar(
 				&install.StartOpts.Sequential, "sequential", false,


### PR DESCRIPTION
roachprod looks for the binary name in PATH
first and then in GOPATH, but looking up in PATH
does not work if the name has a / in it. Fix the 
default value of the binary flag to not have a /.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/147)
<!-- Reviewable:end -->
