### PR TITLE
Fix specification of remote cockroach binary

### DIFF
--- a/install/cockroach.go
+++ b/install/cockroach.go
@@ -24,8 +24,11 @@ var StartOpts struct {
 type Cockroach struct{}
 
 func cockroachNodeBinary(c *SyncedCluster, i int) string {
-	if !c.IsLocal() || filepath.IsAbs(config.Binary) {
+	if filepath.IsAbs(config.Binary) {
 		return config.Binary
+	}
+	if !c.IsLocal() {
+		return "./" + config.Binary
 	}
 
 	path := filepath.Join(fmt.Sprintf(os.ExpandEnv("${HOME}/local/%d"), i), config.Binary)


### PR DESCRIPTION
When running `cockroach` remotely, ensure that path is relative to the
current directory as `PATH` is not set up to contain the current
directory (i.e. the home directory).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/148)
<!-- Reviewable:end -->
