### PR TITLE
Default to using scp for file transfers

### DIFF
--- a/install/cockroach.go
+++ b/install/cockroach.go
@@ -207,7 +207,11 @@ tar cvf certs.tar certs
 				defer os.Remove(tmpfile.Name()) // clean up
 
 				if err := func() error {
-					session, err := ssh.NewSSHSession(c.host(1), c.user(1))
+					if c.UseSCP {
+						return c.scp(fmt.Sprintf("%s@%s:certs.tar", c.user(1), c.host(1)), tmpfile.Name())
+					}
+
+					session, err := ssh.NewSSHSession(c.user(1), c.host(1))
 					if err != nil {
 						return err
 					}

--- a/main.go
+++ b/main.go
@@ -65,6 +65,7 @@ var (
 	tag            string
 	external       = false
 	adminurlOpen   = false
+	useSCP         = true
 )
 
 func sortedClusters() []string {
@@ -142,6 +143,7 @@ Hint: use "roachprod sync" to update the list of available clusters.
 	if tag != "" {
 		c.Tag = "/" + tag
 	}
+	c.UseSCP = useSCP
 	return c, nil
 }
 
@@ -1173,6 +1175,13 @@ func main() {
 	} {
 		cmd.Flags().StringVar(
 			&tag, "tag", "", "the process tag")
+	}
+
+	for _, cmd := range []*cobra.Command{
+		startCmd, putCmd, getCmd,
+	} {
+		cmd.Flags().BoolVar(
+			&useSCP, "scp", useSCP, "use scp for file transfers")
 	}
 
 	for _, cmd := range []*cobra.Command{


### PR DESCRIPTION
Add a `--scp` flag which controls whether to use the builtin scp
implementation or the external `scp` tool. The default is to use the
external `scp` tool which allows for the use of compression and
hopefully avoids the mysterious `i/o timeout` errors. The downside to
using the external `scp` tool is the lack of a progress meter.

Fixes #142
Fixes #150

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/151)
<!-- Reviewable:end -->
