### PR TITLE
bug: Fixes `roachprod ssh ...` not returning error when remote fails.

### DIFF
--- a/main.go
+++ b/main.go
@@ -865,8 +865,7 @@ var runCmd = &cobra.Command{
 		if len(title) > 30 {
 			title = title[:27] + "..."
 		}
-		_ = c.Run(os.Stdout, c.Nodes, title, cmd)
-		return nil
+		return c.Run(os.Stdout, c.Nodes, title, cmd)
 	}),
 }
 


### PR DESCRIPTION
Fixes the issue that when running a command on a node thorugh `roachprod ssh`,
it will return the remote error appropriately.

Fixes #152.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/153)
<!-- Reviewable:end -->
