### PR TITLE
Separate stdout/stderr `run` is invoked in streaming mode

### DIFF
--- a/install/cluster_synced.go
+++ b/install/cluster_synced.go
@@ -293,7 +293,7 @@ done
 	return ch
 }
 
-func (c *SyncedCluster) Run(w io.Writer, nodes []int, title, cmd string) error {
+func (c *SyncedCluster) Run(stdout, stderr io.Writer, nodes []int, title, cmd string) error {
 	// Stream output if we're running the command on only 1 node.
 	stream := len(nodes) == 1
 	var display string
@@ -324,8 +324,8 @@ func (c *SyncedCluster) Run(w io.Writer, nodes []int, title, cmd string) error {
 		}
 
 		if stream {
-			session.SetStdout(w)
-			session.SetStderr(w)
+			session.SetStdout(stdout)
+			session.SetStderr(stderr)
 			errors[i] = session.Run(nodeCmd)
 			return nil, nil
 		}
@@ -342,7 +342,7 @@ func (c *SyncedCluster) Run(w io.Writer, nodes []int, title, cmd string) error {
 
 	if !stream {
 		for i, r := range results {
-			fmt.Fprintf(w, "  %2d: %s\n", nodes[i], r)
+			fmt.Fprintf(stdout, "  %2d: %s\n", nodes[i], r)
 		}
 	}
 

--- a/install/install.go
+++ b/install/install.go
@@ -13,7 +13,7 @@ var Clusters = map[string]*SyncedCluster{}
 func Install(c *SyncedCluster, args []string) error {
 	do := func(title, cmd string) error {
 		var buf bytes.Buffer
-		err := c.Run(&buf, c.Nodes, "installing "+title, cmd)
+		err := c.Run(&buf, &buf, c.Nodes, "installing "+title, cmd)
 		if err != nil {
 			fmt.Print(buf.String())
 		}

--- a/main.go
+++ b/main.go
@@ -867,7 +867,7 @@ var runCmd = &cobra.Command{
 		if len(title) > 30 {
 			title = title[:27] + "..."
 		}
-		return c.Run(os.Stdout, c.Nodes, title, cmd)
+		return c.Run(os.Stdout, os.Stderr, c.Nodes, title, cmd)
 	}),
 }
 


### PR DESCRIPTION
When `run` is invoked on a single target node (i.e. streaming mode),
separate stdout and stderr like a good citizen.

Fixes #154

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/155)
<!-- Reviewable:end -->
