### PR TITLE
Add --json flag to roachprod list command

### DIFF
--- a/cloud/cluster_cloud.go
+++ b/cloud/cluster_cloud.go
@@ -15,10 +15,10 @@ import (
 const vmNameFormat = "user-<clusterid>-<nodeid>"
 
 type Cloud struct {
-	Clusters map[string]*CloudCluster
+	Clusters map[string]*CloudCluster `json:"clusters"`
 	// Any VM in this list can be expected to have at least one element
 	// in its Errors field.
-	BadInstances vm.List
+	BadInstances vm.List `json:"bad_instances"`
 }
 
 // Collate Cloud.BadInstances by errors.
@@ -50,12 +50,12 @@ func newCloud() *Cloud {
 //
 // TODO(benesch): unify with syncedCluster.
 type CloudCluster struct {
-	Name string
-	User string
+	Name string `json:"name"`
+	User string `json:"user"`
 	// This is the earliest creation and shortest lifetime across VMs.
-	CreatedAt time.Time
-	Lifetime  time.Duration
-	VMs       vm.List
+	CreatedAt time.Time     `json:"created_at"`
+	Lifetime  time.Duration `json:"lifetime"`
+	VMs       vm.List       `json:"vms"`
 }
 
 // Clouds returns the names of all of the various cloud providers used

--- a/vm/aws/aws.go
+++ b/vm/aws/aws.go
@@ -365,7 +365,8 @@ func (p *Provider) listRegion(region string) (vm.List, error) {
 					Key   string
 					Value string
 				}
-				VpcId string
+				VpcId        string
+				InstanceType string
 			}
 		}
 	}
@@ -414,18 +415,19 @@ func (p *Provider) listRegion(region string) (vm.List, error) {
 			}
 
 			m := vm.VM{
-				CreatedAt:  createdAt,
-				DNS:        in.PrivateDnsName,
-				Name:       tagMap["Name"],
-				Errors:     errs,
-				Lifetime:   lifetime,
-				PrivateIP:  in.PrivateIpAddress,
-				Provider:   ProviderName,
-				ProviderID: in.InstanceId,
-				PublicIP:   in.PublicIpAddress,
-				RemoteUser: p.opts.RemoteUserName,
-				VPC:        in.VpcId,
-				Zone:       in.Placement.AvailabilityZone,
+				CreatedAt:   createdAt,
+				DNS:         in.PrivateDnsName,
+				Name:        tagMap["Name"],
+				Errors:      errs,
+				Lifetime:    lifetime,
+				PrivateIP:   in.PrivateIpAddress,
+				Provider:    ProviderName,
+				ProviderID:  in.InstanceId,
+				PublicIP:    in.PublicIpAddress,
+				RemoteUser:  p.opts.RemoteUserName,
+				VPC:         in.VpcId,
+				MachineType: in.InstanceType,
+				Zone:        in.Placement.AvailabilityZone,
 			}
 			ret = append(ret, m)
 		}

--- a/vm/gce/gcloud.go
+++ b/vm/gce/gcloud.go
@@ -65,7 +65,8 @@ type jsonVM struct {
 			NatIP string
 		}
 	}
-	Zone string
+	MachineType string
+	Zone        string
 }
 
 // Convert the JSON VM data into our common VM type
@@ -97,10 +98,13 @@ func (jsonVM *jsonVM) toVM(project string) *vm.VM {
 		}
 	}
 
-	// This is splitting and taking the last part of a url path,
-	// which is the zone.
-	zones := strings.Split(jsonVM.Zone, "/")
-	zone := zones[len(zones)-1]
+	// This is splitting and taking the last part of a url path.
+	lastComponent := func(url string) string {
+		s := strings.Split(url, "/")
+		return s[len(s)-1]
+	}
+	machineType := lastComponent(jsonVM.MachineType)
+	zone := lastComponent(jsonVM.Zone)
 
 	return &vm.VM{
 		Name:       jsonVM.Name,
@@ -114,9 +118,10 @@ func (jsonVM *jsonVM) toVM(project string) *vm.VM {
 		PublicIP:   publicIP,
 		// N.B. gcloud uses the local username to log into instances rather
 		// than the username on the authenticated Google account.
-		RemoteUser: config.OSUser.Username,
-		VPC:        vpc,
-		Zone:       zone,
+		RemoteUser:  config.OSUser.Username,
+		VPC:         vpc,
+		MachineType: machineType,
+		Zone:        zone,
 	}
 }
 

--- a/vm/local/local.go
+++ b/vm/local/local.go
@@ -94,16 +94,17 @@ func (p *Provider) List() (ret vm.List, _ error) {
 		now := time.Now()
 		for range sc.VMs {
 			ret = append(ret, vm.VM{
-				Name:       "localhost",
-				CreatedAt:  now,
-				Lifetime:   time.Hour,
-				PrivateIP:  "127.0.0.1",
-				Provider:   ProviderName,
-				ProviderID: ProviderName,
-				PublicIP:   "127.0.0.1",
-				RemoteUser: config.OSUser.Username,
-				VPC:        ProviderName,
-				Zone:       ProviderName,
+				Name:        "localhost",
+				CreatedAt:   now,
+				Lifetime:    time.Hour,
+				PrivateIP:   "127.0.0.1",
+				Provider:    ProviderName,
+				ProviderID:  ProviderName,
+				PublicIP:    "127.0.0.1",
+				RemoteUser:  config.OSUser.Username,
+				VPC:         ProviderName,
+				MachineType: ProviderName,
+				Zone:        ProviderName,
 			})
 		}
 	}

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -15,30 +15,30 @@ import (
 // A VM is an abstract representation of a specific machine instance.  This type is used across
 // the various cloud providers supported by roachprod.
 type VM struct {
-	Name      string
-	CreatedAt time.Time
+	Name      string    `json:"name"`
+	CreatedAt time.Time `json:"created_at"`
 	// If non-empty, indicates that some or all of the data in the VM instance
 	// is not present or otherwise invalid.
-	Errors   []error
-	Lifetime time.Duration
+	Errors   []error       `json:"errors"`
+	Lifetime time.Duration `json:"lifetime"`
 	// The provider-internal DNS name for the VM instance
-	DNS string
+	DNS string `json:"dns"`
 	// The name of the cloud provider that hosts the VM instance
-	Provider string
+	Provider string `json:"provider"`
 	// The provider-specific id for the instance.  This may or may not be the same as Name, depending
 	// on whether or not the cloud provider automatically assigns VM identifiers.
-	ProviderID string
-	PrivateIP  string
-	PublicIP   string
+	ProviderID string `json:"provider_id"`
+	PrivateIP  string `json:"private_ip"`
+	PublicIP   string `json:"public_ip"`
 	// The username that should be used to connect to the VM.
-	RemoteUser string
+	RemoteUser string `json:"remote_user"`
 	// The VPC value defines an equivalency set for VMs that can route
 	// to one another via private IP addresses.  We use this later on
 	// when determining whether or not cluster member should advertise
 	// their public or private IP.
-	VPC         string
-	MachineType string
-	Zone        string
+	VPC         string `json:"vpc"`
+	MachineType string `json:"machine_type"`
+	Zone        string `json:"zone"`
 }
 
 // Error values for VM.Error

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -36,8 +36,9 @@ type VM struct {
 	// to one another via private IP addresses.  We use this later on
 	// when determining whether or not cluster member should advertise
 	// their public or private IP.
-	VPC  string
-	Zone string
+	VPC         string
+	MachineType string
+	Zone        string
 }
 
 // Error values for VM.Error


### PR DESCRIPTION
This flag sets the format of the command output to json. This will
make the output more easily ingestible by other tools.

The PR also makes two minor changes to the VM struct:
- it adds a MachineType field
- it strips the URL path from the VPC string for GCE VMs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/164)
<!-- Reviewable:end -->
