### PR TITLE
Default --treedist to false

### DIFF
--- a/main.go
+++ b/main.go
@@ -65,7 +65,7 @@ var (
 	tag            string
 	external       = false
 	adminurlOpen   = false
-	useTreeDist    = true
+	useTreeDist    = false
 )
 
 func sortedClusters() []string {


### PR DESCRIPTION
It currently requires a local ssh agent to be running for
authentication, which isn't true when run via the roachtest
nightlies. #163 will remove the agent requirement.

See #163

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/165)
<!-- Reviewable:end -->
