### PR TITLE
Add encryption flag to allow roachproad start encrypted cluster

### DIFF
--- a/main.go
+++ b/main.go
@@ -68,6 +68,7 @@ var (
 	external       = false
 	adminurlOpen   = false
 	useTreeDist    = false
+	encrypt        = false
 )
 
 func sortedClusters() []string {
@@ -1227,6 +1228,8 @@ func main() {
 				&nodeEnv, "env", "e", nodeEnv, "node environment variables")
 			cmd.Flags().StringVarP(
 				&clusterType, "type", "t", clusterType, `cluster type ("cockroach" or "cassandra")`)
+			cmd.Flags().BoolVar(
+				&install.StartOpts.Encrypt, "encrypt", encrypt, "start nodes with encryption at rest turned on")
 			fallthrough
 		case pgurlCmd, adminurlCmd, sqlCmd:
 			cmd.Flags().BoolVar(


### PR DESCRIPTION
Added encryption at rest flag `--encrypt` to `roachprod start` to allow
encryption at rest to be used for each nodes.

Part of encryption at rest: #19783.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/170)
<!-- Reviewable:end -->
