### PR TITLE
Add --quiet (-q) flag

### DIFF
--- a/install/cluster_synced.go
+++ b/install/cluster_synced.go
@@ -53,6 +53,7 @@ type SyncedCluster struct {
 	Tag         string
 	Impl        ClusterImpl
 	UseTreeDist bool
+	Quiet       bool
 }
 
 func (c *SyncedCluster) host(index int) string {
@@ -700,7 +701,7 @@ func (c *SyncedCluster) Put(src, dest string) {
 
 	var writer ui.Writer
 	var ticker *time.Ticker
-	if ui.IsStdoutTerminal {
+	if !c.Quiet {
 		ticker = time.NewTicker(100 * time.Millisecond)
 	} else {
 		ticker = time.NewTicker(1000 * time.Millisecond)
@@ -714,7 +715,7 @@ func (c *SyncedCluster) Put(src, dest string) {
 	for done := false; !done; {
 		select {
 		case <-ticker.C:
-			if !ui.IsStdoutTerminal {
+			if c.Quiet {
 				fmt.Printf(".")
 			}
 		case r, ok := <-results:
@@ -730,7 +731,7 @@ func (c *SyncedCluster) Put(src, dest string) {
 				linesMu.Unlock()
 			}
 		}
-		if ui.IsStdoutTerminal {
+		if !c.Quiet {
 			linesMu.Lock()
 			for i := range lines {
 				fmt.Fprintf(&writer, "  %2d: ", c.Nodes[i])
@@ -747,7 +748,7 @@ func (c *SyncedCluster) Put(src, dest string) {
 		}
 	}
 
-	if !ui.IsStdoutTerminal {
+	if c.Quiet {
 		fmt.Printf("\n")
 		linesMu.Lock()
 		for i := range lines {
@@ -874,7 +875,7 @@ func (c *SyncedCluster) Get(src, dest string) {
 	}()
 
 	var ticker *time.Ticker
-	if ui.IsStdoutTerminal {
+	if !c.Quiet {
 		ticker = time.NewTicker(100 * time.Millisecond)
 	} else {
 		ticker = time.NewTicker(1000 * time.Millisecond)
@@ -888,7 +889,7 @@ func (c *SyncedCluster) Get(src, dest string) {
 	for done := false; !done; {
 		select {
 		case <-ticker.C:
-			if !ui.IsStdoutTerminal {
+			if c.Quiet {
 				fmt.Printf(".")
 			}
 		case r, ok := <-results:
@@ -904,7 +905,7 @@ func (c *SyncedCluster) Get(src, dest string) {
 				linesMu.Unlock()
 			}
 		}
-		if ui.IsStdoutTerminal {
+		if !c.Quiet {
 			linesMu.Lock()
 			for i := range lines {
 				fmt.Fprintf(&writer, "  %2d: ", c.Nodes[i])
@@ -921,7 +922,7 @@ func (c *SyncedCluster) Get(src, dest string) {
 		}
 	}
 
-	if !ui.IsStdoutTerminal {
+	if c.Quiet {
 		fmt.Printf("\n")
 		linesMu.Lock()
 		for i := range lines {
@@ -1081,7 +1082,7 @@ func (c *SyncedCluster) Parallel(display string, count, concurrency int, fn func
 	}
 
 	var ticker *time.Ticker
-	if ui.IsStdoutTerminal {
+	if !c.Quiet {
 		ticker = time.NewTicker(100 * time.Millisecond)
 	} else {
 		ticker = time.NewTicker(1000 * time.Millisecond)
@@ -1098,7 +1099,7 @@ func (c *SyncedCluster) Parallel(display string, count, concurrency int, fn func
 	for done := false; !done; {
 		select {
 		case <-ticker.C:
-			if !ui.IsStdoutTerminal {
+			if c.Quiet {
 				fmt.Fprintf(out, ".")
 			}
 		case r, ok := <-results:
@@ -1114,7 +1115,7 @@ func (c *SyncedCluster) Parallel(display string, count, concurrency int, fn func
 			}
 		}
 
-		if ui.IsStdoutTerminal {
+		if !c.Quiet {
 			fmt.Fprint(&writer, display)
 			var n int
 			for i := range complete {
@@ -1132,7 +1133,7 @@ func (c *SyncedCluster) Parallel(display string, count, concurrency int, fn func
 		}
 	}
 
-	if !ui.IsStdoutTerminal {
+	if c.Quiet {
 		fmt.Fprintf(out, "\n")
 	}
 

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/roachprod/vm/local"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"golang.org/x/crypto/ssh/terminal"
 	"golang.org/x/sys/unix"
 )
 
@@ -69,6 +70,7 @@ var (
 	adminurlOpen   = false
 	useTreeDist    = false
 	encrypt        = false
+	quiet          = false
 )
 
 func sortedClusters() []string {
@@ -147,6 +149,7 @@ Hint: use "roachprod sync" to update the list of available clusters.
 		c.Tag = "/" + tag
 	}
 	c.UseTreeDist = useTreeDist
+	c.Quiet = quiet || !terminal.IsTerminal(int(os.Stdout.Fd()))
 	return c, nil
 }
 
@@ -1133,6 +1136,9 @@ func main() {
 		webCmd,
 		dumpCmd,
 	)
+
+	rootCmd.PersistentFlags().BoolVarP(
+		&quiet, "quiet", "q", false, "disable fancy progress output")
 
 	for _, cmd := range []*cobra.Command{createCmd, destroyCmd, extendCmd} {
 		cmd.Flags().StringVarP(&username, "username", "u", os.Getenv("ROACHPROD_USER"),

--- a/ui/writer.go
+++ b/ui/writer.go
@@ -4,13 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"os"
 	"strings"
-
-	"golang.org/x/crypto/ssh/terminal"
 )
-
-var IsStdoutTerminal = terminal.IsTerminal(int(os.Stdout.Fd()))
 
 type Writer struct {
 	buf       bytes.Buffer


### PR DESCRIPTION
The --quiet flag disables the fancy progress display. Useful if you're
using a weird terminal emulator like the emacs shell.

Fixes #162

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/172)
<!-- Reviewable:end -->
