### PR TITLE
web: fix auto-open of HTML chart

### DIFF
--- a/web.go
+++ b/web.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"html/template"
 	"io/ioutil"
+	"os"
 	"os/exec"
+	"path/filepath"
 )
 
 func web(dirs []string) error {
@@ -45,7 +47,11 @@ func webApply(m interface{}) error {
 	if err != nil {
 		return err
 	}
-	f, err := ioutil.TempFile("", "web")
+	dir, err := ioutil.TempDir("", "roachprod-web")
+	if err != nil {
+		return err
+	}
+	f, err := os.Create(filepath.Join(dir, "index.html")) // .html extension required for open to work
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
'roachprod web' attempts to automatically open an HTML chart. On my
machine, this only works if the file has a .html extension.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/173)
<!-- Reviewable:end -->
