### PR TITLE
roachprod: add graceful shutdown flag to stop command

### DIFF
--- a/install/cluster_synced.go
+++ b/install/cluster_synced.go
@@ -123,7 +123,7 @@ func (c *SyncedCluster) newSession(i int) (session, error) {
 	return &remoteSession{s}, nil
 }
 
-func (c *SyncedCluster) Stop() {
+func (c *SyncedCluster) Stop(sig int) {
 	display := fmt.Sprintf("%s: stopping", c.Name)
 	c.Parallel(display, len(c.Nodes), 0, func(i int) ([]byte, error) {
 		session, err := c.newSession(c.Nodes[i])
@@ -136,15 +136,15 @@ func (c *SyncedCluster) Stop() {
 		// awk process match its own output from `ps`.
 		cmd := fmt.Sprintf(`ps axeww -o pid -o command | \
   sed 's/export ROACHPROD=//g' | \
-  awk '/ROACHPROD=(%d%s)[ \/]/ { print $1 }' | xargs kill -9 || true;`,
-			c.Nodes[i], c.escapedTag())
+  awk '/ROACHPROD=(%d%s)[ \/]/ { print $1 }' | xargs kill -%d || true;`,
+			c.Nodes[i], c.escapedTag(), sig)
 		return session.CombinedOutput(cmd)
 	})
 }
 
 func (c *SyncedCluster) Wipe() {
 	display := fmt.Sprintf("%s: wiping", c.Name)
-	c.Stop()
+	c.Stop(9)
 	c.Parallel(display, len(c.Nodes), 0, func(i int) ([]byte, error) {
 		session, err := c.newSession(c.Nodes[i])
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -71,6 +71,7 @@ var (
 	useTreeDist    = false
 	encrypt        = false
 	quiet          = false
+	sig            = 9
 )
 
 func sortedClusters() []string {
@@ -773,15 +774,19 @@ cluster setting will be set to its value.
 }
 
 var stopCmd = &cobra.Command{
-	Use:   "stop <cluster>",
+	Use:   "stop <cluster> [--sig]",
 	Short: "stop nodes on a cluster",
 	Long: `Stop nodes on a cluster.
 
 Stop roachprod created processes running on the nodes in a cluster, including
 processes started by the "start", "run" and "ssh" commands. Every process
 started by roachprod is tagged with a ROACHPROD=<node> environment variable
-which is used by "stop" to locate the processes and terminate them. Processes
-are killed with signal 9 (SIGKILL) giving them no chance for a graceful exit.
+which is used by "stop" to locate the processes and terminate them. By default
+processes are killed with signal 9 (SIGKILL) giving them no chance for a graceful
+exit.
+
+The --sig flag will pass a signal to kill to allow us finer control over how we
+shutdown cockroach.
 ` + tagHelp + `
 `,
 	Args: cobra.ExactArgs(1),
@@ -790,7 +795,7 @@ are killed with signal 9 (SIGKILL) giving them no chance for a graceful exit.
 		if err != nil {
 			return err
 		}
-		c.Stop()
+		c.Stop(sig)
 		return nil
 	}),
 }
@@ -1257,6 +1262,8 @@ func main() {
 
 	startCmd.Flags().IntVarP(&numRacks,
 		"racks", "r", 0, "the number of racks to partition the nodes into")
+
+	stopCmd.Flags().IntVar(&sig, "sig", 9, "signal to pass to kill.")
 
 	testCmd.Flags().DurationVarP(
 		&duration, "duration", "d", 5*time.Minute, "the duration to run each test")

--- a/tests.go
+++ b/tests.go
@@ -391,7 +391,7 @@ func kvTest(clusterName, testName, dir, cmd string) {
 			break
 		}
 	}
-	c.Stop()
+	c.Stop(9)
 }
 
 func kv0(clusterName, dir string) {
@@ -487,7 +487,7 @@ func nightly(clusterName, dir string) {
 			break
 		}
 	}
-	c.Stop()
+	c.Stop(9)
 }
 
 func splits(clusterName, dir string) {
@@ -546,7 +546,7 @@ func splits(clusterName, dir string) {
 			if err := c.RunLoad(cmd, stdout, stderr); err != nil {
 				return err
 			}
-			c.Stop()
+			c.Stop(9)
 			return nil
 		}()
 		if err != nil {
@@ -556,5 +556,5 @@ func splits(clusterName, dir string) {
 			break
 		}
 	}
-	c.Stop()
+	c.Stop(9)
 }


### PR DESCRIPTION
Before this patch the stop command would send the cockroach process
a kill -9. Now when using a --shutdown flag it will send a SIGTERM
to allow the process to shutdown gracefully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/177)
<!-- Reviewable:end -->
