### PR TITLE
Error instead of panic'ing on an invalid cluster

### DIFF
--- a/install/cluster_synced.go
+++ b/install/cluster_synced.go
@@ -412,6 +412,11 @@ func (c *SyncedCluster) SetupSSH() error {
 		return nil
 	}
 
+	if len(c.Nodes) == 0 || len(c.Users) == 0 || len(c.VMs) == 0 {
+		return fmt.Errorf("%s: invalid cluster: nodes=%d users=%d hosts=%d",
+			c.Name, len(c.Nodes), len(c.Users), len(c.VMs))
+	}
+
 	// Generate an ssh key that we'll distribute to all of the nodes in the
 	// cluster in order to allow inter-node ssh.
 	var msg string


### PR DESCRIPTION
There is evidence from nightly roachtest failures that cluster creation
is generating a cluster without any nodes. Not sure how this is
happening, but provide a better error message when it does to help
diagnose the problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/180)
<!-- Reviewable:end -->
