### PR TITLE
Rework the mechanism to wait for a node to be initialized

### DIFF
--- a/install/cluster_synced.go
+++ b/install/cluster_synced.go
@@ -378,13 +378,8 @@ func (c *SyncedCluster) Wait() error {
 			}
 			defer session.Close()
 
-			// Wait for the startup scripts to complete.
-			out, err := session.CombinedOutput("systemctl show google-startup-scripts -p ActiveState")
+			_, err = session.CombinedOutput("test -e /mnt/data1/.roachprod-initialized")
 			if err != nil {
-				errs[i] = err
-				return nil, nil
-			}
-			if strings.TrimSpace(string(out)) == "ActiveState=activating" {
 				time.Sleep(500 * time.Millisecond)
 				continue
 			}

--- a/vm/aws/support.go
+++ b/vm/aws/support.go
@@ -36,6 +36,7 @@ if [ "${disknum}" -eq "0" ]; then
   mkdir -p /mnt/data1
   chmod 777 /mnt/data1
 fi
+sudo touch /mnt/data1/.roachprod-initialized
 `
 
 // runCommand is used to invoke an AWS command for which no output is expected.

--- a/vm/gce/utils.go
+++ b/vm/gce/utils.go
@@ -31,6 +31,7 @@ fi
 sudo chmod 777 /mnt/data1
 # sshguard can prevent frequent ssh connections to the same host. Disable it.
 sudo service sshguard stop
+sudo touch /mnt/data1/.roachprod-initialized
 `
 
 // write the startup script to a temp file.


### PR DESCRIPTION
The startup script now touches /mnt/data1/.roachprod-initialized when
initialization is coimplete. SyncedCluster.Wait waits for that file to
appear. The hope is that this is more robust than waiting for systemctl
and it also works on AWS.