### PR TITLE
Default --treedist to false

### DIFF
--- a/main.go
+++ b/main.go
@@ -68,7 +68,7 @@ var (
 	tag            string
 	external       = false
 	adminurlOpen   = false
-	useTreeDist    = true
+	useTreeDist    = false
 	encrypt        = false
 	quiet          = false
 	sig            = 9


### PR DESCRIPTION
A handful of nightly tests failed with errors that look related to
treedist (`roachprod put` failures). Turning it off by default until I
have time to investigate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/184)
<!-- Reviewable:end -->
