### PR TITLE
roachprod: disambiguate confusing log

### DIFF
--- a/install/cluster_synced.go
+++ b/install/cluster_synced.go
@@ -772,7 +772,7 @@ func (c *SyncedCluster) Put(src, dest string) {
 	}
 
 	if haveErr {
-		log.Fatal("failed")
+		log.Fatalf("put %s failed", src)
 	}
 }
 
@@ -946,7 +946,7 @@ func (c *SyncedCluster) Get(src, dest string) {
 	}
 
 	if haveErr {
-		log.Fatal("failed")
+		log.Fatalf("get %s failed", src)
 	}
 }
 


### PR DESCRIPTION
`roachprod get` is called by `roachtest` when collecting logs, but the
output "failed" isn't linked to that operation in particular and looks
like something funky might be going on in the test. Be more specific.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/189)
<!-- Reviewable:end -->
