### PR TITLE
roachprod: Add 'stage' command.

### DIFF
--- a/install/staging.go
+++ b/install/staging.go
@@ -1,0 +1,84 @@
+package install
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+)
+
+const (
+	edgeBinaryServer    = "https://edge-binaries.cockroachdb.com"
+	releaseBinaryServer = "https://s3.amazonaws.com/binaries.cockroachdb.com/"
+)
+
+func getEdgeBinaryURL(binaryName string, SHA string) (*url.URL, error) {
+	edgeBinaryLocation, err := url.Parse(edgeBinaryServer)
+	if err != nil {
+		return nil, err
+	}
+	edgeBinaryLocation.Path = binaryName
+	// If a specific SHA is provided, just attach that.
+	if len(SHA) > 0 {
+		edgeBinaryLocation.Path += "." + SHA
+	} else {
+		edgeBinaryLocation.Path += ".LATEST"
+		// Otherwise, find the latest SHA binary available. This works because
+		// "[executable].LATEST" redirects to the latest SHA.
+		resp, err := http.Head(edgeBinaryLocation.String())
+		if err != nil {
+			return nil, err
+		}
+		edgeBinaryLocation = resp.Request.URL
+	}
+
+	return edgeBinaryLocation, nil
+}
+
+// StageRemoteBinary downloads a cockroach edge binary with the provided
+// application path to each specified by the cluster. If no SHA is specified,
+// the latest build of the binary is used instead.
+func StageRemoteBinary(c *SyncedCluster, applicationName, binaryPath, SHA string) error {
+	binURL, err := getEdgeBinaryURL(binaryPath, SHA)
+	if err != nil {
+		return err
+	}
+	fmt.Println("Resolved binary url for %s: %s", applicationName, binURL)
+	cmdStr := fmt.Sprintf(
+		`curl -sfSL -o %s "%s" && chmod 755 ./%s`, applicationName, binURL, applicationName,
+	)
+	return c.Run(
+		os.Stdout, os.Stderr, c.Nodes, fmt.Sprintf("staging binary (%s)", applicationName), cmdStr,
+	)
+}
+
+// StageCockroachRelease downloads an official CockroachDB release binary with
+// the specified version.
+func StageCockroachRelease(c *SyncedCluster, version string) error {
+	if len(version) == 0 {
+		return fmt.Errorf(
+			"release application cannot be staged without specifying a specific version",
+		)
+	}
+	binURL, err := url.Parse(releaseBinaryServer)
+	if err != nil {
+		return err
+	}
+	binURL.Path += fmt.Sprintf("cockroach-%s.linux-amd64.tgz", version)
+	fmt.Println("Resolved release url for cockroach version %s: %s", version, binURL)
+
+	// This command incantation:
+	// - Creates a temporary directory on the remote machine
+	// - Downloads and unpacks the cockroach release into the temp directory
+	// - Moves the cockroach executable from the binary to '/.' and gives it
+	// the correct permissions.
+	cmdStr := fmt.Sprintf(`
+tmpdir="$(mktemp -d /tmp/cockroach-release.XXX)" && \
+curl -f -s -S -o- %s | tar xfz - -C "${tmpdir}" --strip-components 1 && \
+mv ${tmpdir}/cockroach ./cockroach && \
+chmod 755 ./cockroach
+`, binURL)
+	return c.Run(
+		os.Stdout, os.Stderr, c.Nodes, "staging cockroach release binary", cmdStr,
+	)
+}


### PR DESCRIPTION
Adds a first version of a `roachprod stage` command, allowing users to
download official release and edge binaries directly to roachprod
clusters. When installing edge binaries, an optional SHA can be
specified to download a specific build; if no SHA is specified, the
latest version is downloaded. For release binaries, a specific release
version must be specified.

Example Syntax is as follows:

`roachprod stage my-cluster cockroach
e90e6903fee7dd0f88e20e345c2ddfe1af1e5a97`
`roachprod stage my-cluster workload`
`roachprod stage my-cluster release v2.0.5`

Currently supported applications are "cockroach" (edge binary),
"workload", and "release" (cockroach official release).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/190)
<!-- Reviewable:end -->
