### PR TITLE
Add docker as an install target

### DIFF
--- a/install/install.go
+++ b/install/install.go
@@ -3,6 +3,7 @@ package install
 import (
 	"bytes"
 	"fmt"
+	"sort"
 
 	"github.com/hashicorp/go-version"
 )
@@ -63,6 +64,15 @@ sudo apt-get install -y \
 sudo apt-get update;
 sudo apt-get install -y \
   zfsutils-linux`,
+}
+
+func SortedCmds() []string {
+	cmds := make([]string, 0, len(installCmds))
+	for cmd := range installCmds {
+		cmds = append(cmds, cmd)
+	}
+	sort.Strings(cmds)
+	return cmds
 }
 
 func Install(c *SyncedCluster, args []string) error {

--- a/install/install.go
+++ b/install/install.go
@@ -21,6 +21,23 @@ sudo apt-get install -y cassandra;
 sudo service cassandra stop;
 `,
 
+	"docker": `
+sudo apt-get update;
+sudo apt-get install  -y \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    software-properties-common;
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -;
+sudo add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+   $(lsb_release -cs) \
+   stable";
+
+sudo apt-get update;
+sudo apt-get install  -y docker-ce;
+`,
+
 	"gcc": `
 sudo apt-get update;
 sudo apt-get install -y gcc;
@@ -28,12 +45,12 @@ sudo apt-get install -y gcc;
 
 	// graphviz and rlwrap are useful for pprof
 	"go": `
-sudo apt-get update
-sudo apt-get install -y graphviz rlwrap
+sudo apt-get update;
+sudo apt-get install -y graphviz rlwrap;
 
-curl https://dl.google.com/go/go1.9.3.linux-amd64.tar.gz | sudo tar -C /usr/local -xz
-echo 'export PATH=$PATH:/usr/local/go/bin' | sudo tee /etc/profile.d/go.sh > /dev/null
-sudo chmod +x /etc/profile.d/go.sh
+curl https://dl.google.com/go/go1.9.3.linux-amd64.tar.gz | sudo tar -C /usr/local -xz;
+echo 'export PATH=$PATH:/usr/local/go/bin' | sudo tee /etc/profile.d/go.sh > /dev/null;
+sudo chmod +x /etc/profile.d/go.sh;
 `,
 
 	"haproxy": `
@@ -63,7 +80,8 @@ sudo apt-get install -y \
 	"zfs": `
 sudo apt-get update;
 sudo apt-get install -y \
-  zfsutils-linux`,
+  zfsutils-linux;
+`,
 }
 
 func SortedCmds() []string {

--- a/main.go
+++ b/main.go
@@ -967,7 +967,7 @@ var testCmd = &cobra.Command{
 	Short: "run one or more tests on a cluster",
 	Long: `Run one or more tests on a cluster. The test <name> must be one of:
 
-	` + strings.Join(allTests(), "\n\t") + `
+    ` + strings.Join(allTests(), "\n    ") + `
 
 Alternately, an interrupted test can be resumed by specifying the output
 directory of a previous test. For example:
@@ -992,12 +992,7 @@ var installCmd = &cobra.Command{
 	Short: "install 3rd party software",
 	Long: `Install third party software. Currently available installation options are:
 
-  cassandra
-  gcc
-  mongodb
-  ntp
-  postgres
-  tools (fio, iftop, perf)
+    ` + strings.Join(install.SortedCmds(), "\n    ") + `
 `,
 	Args: cobra.MinimumNArgs(2),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
This allows users to run jaeger with the following one-liner

```
roachprod run <cluster>:<node> -- 'sudo docker run -d --name jaeger \
  -e COLLECTOR_ZIPKIN_HTTP_PORT=9411 \
  -p 5775:5775/udp \
  -p 6831:6831/udp \
  -p 6832:6832/udp \
  -p 5778:5778 \
  -p 16686:16686 \
  -p 14268:14268 \
  -p 9411:9411 \
  jaegertracing/all-in-one:latest'
```

The meat of that command is from
https://www.jaegertracing.io/docs/getting-started/#all-in-one-docker-image.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/191)
<!-- Reviewable:end -->
