### PR TITLE
Use ssh instead of golang.org/x/crypto/ssh

### DIFF
--- a/install/cluster_synced.go
+++ b/install/cluster_synced.go
@@ -94,7 +94,7 @@ func (c *SyncedCluster) GetInternalIP(index int) (string, error) {
 		return c.host(index), nil
 	}
 
-	session, err := ssh.NewSSHSession(c.user(index), c.host(index))
+	session, err := c.newSession(index)
 	if err != nil {
 		return "", nil
 	}
@@ -116,12 +116,7 @@ func (c *SyncedCluster) newSession(i int) (session, error) {
 	if c.IsLocal() {
 		return newLocalSession(), nil
 	}
-
-	s, err := ssh.NewSSHSession(c.user(i), c.host(i))
-	if err != nil {
-		return nil, err
-	}
-	return &remoteSession{s}, nil
+	return newRemoteSession(c.user(i), c.host(i))
 }
 
 func (c *SyncedCluster) Stop(sig int) {


### PR DESCRIPTION
This is an attempt to avoid the 'dial tcp ... i/o timeout' problems seen
in cockroachdb/cockroach#29578.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/200)
<!-- Reviewable:end -->
