### PR TITLE
Don't sync filtered cluster list to hosts file

### DIFF
--- a/cloud/cluster_cloud.go
+++ b/cloud/cluster_cloud.go
@@ -21,6 +21,16 @@ type Cloud struct {
 	BadInstances vm.List `json:"bad_instances"`
 }
 
+// Clone creates a deep copy of the receiver.
+func (c *Cloud) Clone() *Cloud {
+	cc := *c
+	cc.Clusters = make(map[string]*CloudCluster, len(c.Clusters))
+	for k, v := range c.Clusters {
+		cc.Clusters[k] = v
+	}
+	return &cc
+}
+
 // Collate Cloud.BadInstances by errors.
 func (c *Cloud) BadInstanceErrors() map[error]vm.List {
 	ret := map[error]vm.List{}

--- a/main.go
+++ b/main.go
@@ -531,13 +531,14 @@ hosts file.
 			return err
 		}
 
-		// Filter and sort by cluster names for stable output
+		// Filter and sort by cluster names for stable output.
 		var names []string
+		filteredCloud := cloud.Clone()
 		for name := range cloud.Clusters {
 			if listPattern.MatchString(name) {
 				names = append(names, name)
 			} else {
-				delete(cloud.Clusters, name)
+				delete(filteredCloud.Clusters, name)
 			}
 		}
 		sort.Strings(names)
@@ -549,14 +550,14 @@ hosts file.
 
 			enc := json.NewEncoder(os.Stdout)
 			enc.SetIndent("", "  ")
-			if err := enc.Encode(cloud); err != nil {
+			if err := enc.Encode(filteredCloud); err != nil {
 				return err
 			}
 		} else {
 			// Align columns left and separate with at least two spaces.
 			tw := tabwriter.NewWriter(os.Stdout, 0, 8, 2, ' ', 0)
 			for _, name := range names {
-				c := cloud.Clusters[name]
+				c := filteredCloud.Clusters[name]
 				if listDetails {
 					c.PrintDetails()
 				} else {
@@ -575,7 +576,7 @@ hosts file.
 
 			// Optionally print any dangling instances with errors
 			if listDetails {
-				collated := cloud.BadInstanceErrors()
+				collated := filteredCloud.BadInstanceErrors()
 
 				// Sort by Error() value for stable output
 				var errors ui.ErrorsByError


### PR DESCRIPTION
Before this change, it was possible to see `unknown cluster` errors
when running multiple roachtest instances at once. The reason for
this was that any `roachprod list` command that included a filter
would only sync clusters matching that filter. This change removes
this bug by syncing the unfiltered cluster list instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/201)
<!-- Reviewable:end -->
