### PR TITLE
add uiport expander

### DIFF
--- a/install/cassandra.go
+++ b/install/cassandra.go
@@ -96,6 +96,10 @@ func (Cassandra) NodePort(c *SyncedCluster, index int) int {
 	return 9042
 }
 
+func (Cassandra) NodeUIPort(c *SyncedCluster, index int) int {
+	return 0 // unimplemented
+}
+
 func makeCassandraYAML(c *SyncedCluster) (string, error) {
 	ip, err := c.GetInternalIP(c.ServerNodes()[0])
 	if err != nil {

--- a/install/cluster_synced.go
+++ b/install/cluster_synced.go
@@ -31,6 +31,7 @@ type ClusterImpl interface {
 	LogDir(c *SyncedCluster, index int) string
 	NodeURL(c *SyncedCluster, host string, port int) string
 	NodePort(c *SyncedCluster, index int) int
+	NodeUIPort(c *SyncedCluster, index int) int
 }
 
 // A SyncedCluster is created from the information in the synced hosts file

--- a/install/cockroach.go
+++ b/install/cockroach.go
@@ -449,6 +449,10 @@ func (Cockroach) NodePort(c *SyncedCluster, index int) int {
 	return port
 }
 
+func (cr Cockroach) NodeUIPort(c *SyncedCluster, index int) int {
+	return GetAdminUIPort(cr.NodePort(c, index))
+}
+
 func (r Cockroach) SQL(c *SyncedCluster, args []string) error {
 	if len(args) == 0 || len(c.Nodes) == 1 {
 		// If no arguments, we're going to get an interactive SQL shell. Require


### PR DESCRIPTION
This is going to be "necessary" (we could also hard-code the ports, but
that sounds wrong) for an improved decommissioning acceptance test which
verifies the /health?ready=1 endpoint.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/203)
<!-- Reviewable:end -->
