### PR TITLE
Avoid looping on netcat in monitor

### DIFF
--- a/install/cluster_synced.go
+++ b/install/cluster_synced.go
@@ -261,6 +261,7 @@ while :; do
 
   if [ -n "${lastpid}" ]; then
     nc localhost %[1]d >/dev/null 2>&1
+    echo nc exited
   else
     sleep 1
   fi
@@ -275,6 +276,9 @@ done
 				return
 			}
 			// Give the session a valid stdin pipe so that nc won't exit immediately.
+			// When nc does exit, we write to stdout, which has a side effect of
+			// checking whether the stdout pipe has broken. This allows us to detect
+			// when the roachprod process is killed.
 			inPipe, err := session.StdinPipe()
 			if err != nil {
 				ch <- nodeMonitorInfo{nodes[i], err.Error()}


### PR DESCRIPTION
This fixes https://github.com/cockroachdb/cockroach/issues/27815. I'm not sure of a better way to detect when the parent process dies and I wasn't able to get an approach that tested stdout without writing to it (e.g. replacing `while :; do` with `while [ -t 1 ]; do`).

We could also push this logic into roachprod itself by catching the signal and killing all child processes before exiting. That's less clean though, and I'm afraid of any fallout that will have.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/204)
<!-- Reviewable:end -->
