### PR TITLE
Increase the default maximum number of open file descriptors

### DIFF
--- a/vm/gce/utils.go
+++ b/vm/gce/utils.go
@@ -31,6 +31,9 @@ fi
 sudo chmod 777 /mnt/data1
 # sshguard can prevent frequent ssh connections to the same host. Disable it.
 sudo service sshguard stop
+# increase the default maximum number of open file descriptors. Load generators
+# running a lot of concurrent workers bump into this often.
+sudo sh -c 'echo "* - nofile 65536" > /etc/security/limits.d/10-roachprod-nofiles.conf'
 sudo touch /mnt/data1/.roachprod-initialized
 `
 


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/cockroach/issues/30669.

Once this is merged, we can go back and remove any `ulimit -n`
invocations from roachtests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/207)
<!-- Reviewable:end -->
