### PR TITLE
Increase default maximum open file descriptors for root user

### DIFF
--- a/vm/gce/utils.go
+++ b/vm/gce/utils.go
@@ -31,9 +31,10 @@ fi
 sudo chmod 777 /mnt/data1
 # sshguard can prevent frequent ssh connections to the same host. Disable it.
 sudo service sshguard stop
-# increase the default maximum number of open file descriptors. Load generators
-# running a lot of concurrent workers bump into this often.
-sudo sh -c 'echo "* - nofile 65536" > /etc/security/limits.d/10-roachprod-nofiles.conf'
+# increase the default maximum number of open file descriptors for
+# root and non-root users. Load generators running a lot of concurrent
+# workers bump into this often.
+sudo sh -c 'echo "root - nofile 65536\n* - nofile 65536" > /etc/security/limits.d/10-roachprod-nofiles.conf'
 sudo touch /mnt/data1/.roachprod-initialized
 `
 


### PR DESCRIPTION
The * in `/etc/security/limits.conf` does not apply to the root user. See https://stackoverflow.com/questions/38991351/why-in-etc-security-limits-conf-doesnt-include-root-user.

This means that previous attempts to increase the default max open file descriptors limit did not have an effect on nightly roachtest runs triggered by teamcity, which are run by root.

This commit increases the fd limit for the root user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/209)
<!-- Reviewable:end -->
