### PR TITLE
Bump GCE Ubuntu image

### DIFF
--- a/vm/gce/gcloud.go
+++ b/vm/gce/gcloud.go
@@ -226,7 +226,7 @@ func (p *Provider) Create(names []string, opts vm.CreateOpts) error {
 		"--subnet", "default",
 		"--maintenance-policy", "MIGRATE",
 		"--scopes", "default,storage-rw",
-		"--image", "ubuntu-1604-xenial-v20171002",
+		"--image", "ubuntu-1604-xenial-v20181004",
 		"--image-project", "ubuntu-os-cloud",
 		"--boot-disk-size", "10",
 		"--boot-disk-type", "pd-ssd",


### PR DESCRIPTION
See the deprecation warning in https://github.com/cockroachdb/cockroach/issues/28921#issuecomment-428899292

We should probably move to 18.04, but there's likely fallout and I don't
want to do it right now.