### PR TITLE
explicitly list id_rsa identity when SSHing

### DIFF
--- a/install/cluster_synced.go
+++ b/install/cluster_synced.go
@@ -1012,6 +1012,7 @@ func (c *SyncedCluster) Ssh(sshArgs, args []string) error {
 		allArgs = []string{
 			"ssh",
 			fmt.Sprintf("%s@%s", c.user(c.Nodes[0]), c.host(c.Nodes[0])),
+			"-i", filepath.Join(config.OSUser.HomeDir, ".ssh", "id_rsa"),
 			"-i", filepath.Join(config.OSUser.HomeDir, ".ssh", "google_compute_engine"),
 			"-o", "StrictHostKeyChecking=no",
 		}

--- a/install/session.go
+++ b/install/session.go
@@ -32,6 +32,7 @@ func newRemoteSession(user, host string) (*remoteSession, error) {
 	cmd := exec.CommandContext(ctx,
 		"ssh",
 		user+"@"+host,
+		"-i", filepath.Join(config.OSUser.HomeDir, ".ssh", "id_rsa"),
 		"-i", filepath.Join(config.OSUser.HomeDir, ".ssh", "google_compute_engine"),
 		"-o", "StrictHostKeyChecking=no",
 	)


### PR DESCRIPTION
Because we specify `-i ~/.ssh/google_compute_engine` when SSHing, ssh
will not attempt to authenticate with the default identity
~/.ssh/id_rsa`. This causes problems for AWS clusters, which use the
default identity and not the google_compute_engine identity.

(Note that this bug does not occur when using a properly configured SSH
agent, but doing so is not a requirement for using roachprod and there
is no SSH agent present on TeamCity.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/214)
<!-- Reviewable:end -->
