### PR TITLE
Add --wait flag to the stop command

### DIFF
--- a/install/cluster_synced.go
+++ b/install/cluster_synced.go
@@ -120,28 +120,55 @@ func (c *SyncedCluster) newSession(i int) (session, error) {
 	return newRemoteSession(c.user(i), c.host(i))
 }
 
-func (c *SyncedCluster) Stop(sig int) {
+func (c *SyncedCluster) Stop(sig int, wait bool) {
 	display := fmt.Sprintf("%s: stopping", c.Name)
+	if wait {
+		display += " and waiting"
+	}
 	c.Parallel(display, len(c.Nodes), 0, func(i int) ([]byte, error) {
 		session, err := c.newSession(c.Nodes[i])
 		if err != nil {
 			return nil, err
 		}
 		defer session.Close()
-		// NB: xargs --no-run-if-empty is not supported on OSX.
+
 		// NB: the awkward-looking `awk` invocation serves to avoid having the
 		// awk process match its own output from `ps`.
-		cmd := fmt.Sprintf(`ps axeww -o pid -o command | \
-  sed 's/export ROACHPROD=//g' | \
-  awk '/ROACHPROD=(%d%s)[ \/]/ { print $1 }' | xargs kill -%d || true;`,
-			c.Nodes[i], c.escapedTag(), sig)
+		cmd := fmt.Sprintf(`count=0
+while :; do
+  pids=$(ps axeww -o pid -o command | \
+    sed 's/export ROACHPROD=//g' | \
+    awk '/ROACHPROD=(%d%s)[ \/]/ { print $1 }')
+  if [ -z "${pids}" ]; then
+    break
+  fi
+`, c.Nodes[i], c.escapedTag())
+
+		if wait {
+			cmd += `
+  if [ ${count} -gt 0 ]; then
+    sleep 1
+  fi
+  ((count++))
+`
+		}
+
+		cmd += fmt.Sprintf(`
+  kill -%d ${pids}
+`, sig)
+
+		if !wait {
+			cmd += "  break\n"
+		}
+		cmd += "done\n"
+
 		return session.CombinedOutput(cmd)
 	})
 }
 
 func (c *SyncedCluster) Wipe() {
 	display := fmt.Sprintf("%s: wiping", c.Name)
-	c.Stop(9)
+	c.Stop(9, true /* wait */)
 	c.Parallel(display, len(c.Nodes), 0, func(i int) ([]byte, error) {
 		session, err := c.newSession(c.Nodes[i])
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -72,6 +72,7 @@ var (
 	encrypt        = false
 	quiet          = false
 	sig            = 9
+	waitFlag       = false
 )
 
 func sortedClusters() []string {
@@ -775,7 +776,7 @@ cluster setting will be set to its value.
 }
 
 var stopCmd = &cobra.Command{
-	Use:   "stop <cluster> [--sig]",
+	Use:   "stop <cluster> [--sig] [--wait]",
 	Short: "stop nodes on a cluster",
 	Long: `Stop nodes on a cluster.
 
@@ -787,7 +788,11 @@ processes are killed with signal 9 (SIGKILL) giving them no chance for a gracefu
 exit.
 
 The --sig flag will pass a signal to kill to allow us finer control over how we
-shutdown cockroach.
+shutdown cockroach. The --wait flag causes stop to loop waiting for all
+processes with the ROACHPROD=<node> environment variable to exit. Note that
+stop will wait forever if you specify --wait with a non-terminating signal
+(e.g. SIGHUP). --wait defaults to true for signal 9 (SIGKILL) and false for all
+other signals.
 ` + tagHelp + `
 `,
 	Args: cobra.ExactArgs(1),
@@ -796,7 +801,11 @@ shutdown cockroach.
 		if err != nil {
 			return err
 		}
-		c.Stop(sig)
+		wait := waitFlag
+		if sig == 9 /* SIGKILL */ && !cmd.Flags().Changed("wait") {
+			wait = true
+		}
+		c.Stop(sig, wait)
 		return nil
 	}),
 }
@@ -1311,7 +1320,8 @@ func main() {
 	startCmd.Flags().IntVarP(&numRacks,
 		"racks", "r", 0, "the number of racks to partition the nodes into")
 
-	stopCmd.Flags().IntVar(&sig, "sig", 9, "signal to pass to kill.")
+	stopCmd.Flags().IntVar(&sig, "sig", sig, "signal to pass to kill")
+	stopCmd.Flags().BoolVar(&waitFlag, "wait", waitFlag, "wait for processes to exit")
 
 	testCmd.Flags().DurationVarP(
 		&duration, "duration", "d", 5*time.Minute, "the duration to run each test")

--- a/tests.go
+++ b/tests.go
@@ -391,7 +391,7 @@ func kvTest(clusterName, testName, dir, cmd string) {
 			break
 		}
 	}
-	c.Stop(9)
+	c.Stop(9, true /* wait */)
 }
 
 func kv0(clusterName, dir string) {
@@ -487,7 +487,7 @@ func nightly(clusterName, dir string) {
 			break
 		}
 	}
-	c.Stop(9)
+	c.Stop(9, true /* wait */)
 }
 
 func splits(clusterName, dir string) {
@@ -546,7 +546,7 @@ func splits(clusterName, dir string) {
 			if err := c.RunLoad(cmd, stdout, stderr); err != nil {
 				return err
 			}
-			c.Stop(9)
+			c.Stop(9, true /* wait */)
 			return nil
 		}()
 		if err != nil {
@@ -556,5 +556,5 @@ func splits(clusterName, dir string) {
 			break
 		}
 	}
-	c.Stop(9)
+	c.Stop(9, true /* wait */)
 }


### PR DESCRIPTION
You can shoot yourself in the foot by specifying a non-terminating
signal with `--wait`. For example, `--sig=1 --wait` will block forever.

Fixes #219

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/220)
<!-- Reviewable:end -->
