### PR TITLE
Disable host key checking in non-interactive sessions

### DIFF
--- a/install/session.go
+++ b/install/session.go
@@ -32,6 +32,7 @@ type remoteSession struct {
 func newRemoteSession(user, host string) (*remoteSession, error) {
 	args := []string{
 		user + "@" + host,
+		"-o", "UserKnownHostsFile=/dev/null",
 		"-o", "StrictHostKeyChecking=no",
 	}
 	args = append(args, sshAuthArgs()...)


### PR DESCRIPTION
IP reuse is frequent in our GCE test clusters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/224)
<!-- Reviewable:end -->
