### PR TITLE
Only specify keys which exist

### DIFF
--- a/install/cluster_synced.go
+++ b/install/cluster_synced.go
@@ -1039,10 +1039,9 @@ func (c *SyncedCluster) Ssh(sshArgs, args []string) error {
 		allArgs = []string{
 			"ssh",
 			fmt.Sprintf("%s@%s", c.user(c.Nodes[0]), c.host(c.Nodes[0])),
-			"-i", filepath.Join(config.OSUser.HomeDir, ".ssh", "id_rsa"),
-			"-i", filepath.Join(config.OSUser.HomeDir, ".ssh", "google_compute_engine"),
 			"-o", "StrictHostKeyChecking=no",
 		}
+		allArgs = append(allArgs, sshAuthArgs()...)
 		allArgs = append(allArgs, sshArgs...)
 		if len(args) > 0 {
 			allArgs = append(allArgs, fmt.Sprintf("export ROACHPROD=%d%s ;", c.Nodes[0], c.Tag))
@@ -1060,11 +1059,10 @@ func (c *SyncedCluster) Ssh(sshArgs, args []string) error {
 func (c *SyncedCluster) scp(src, dest string) error {
 	args := []string{
 		"scp", "-r", "-C",
-		"-i", filepath.Join(config.OSUser.HomeDir, ".ssh", "id_rsa"),
-		"-i", filepath.Join(config.OSUser.HomeDir, ".ssh", "google_compute_engine"),
 		"-o", "StrictHostKeyChecking=no",
-		src, dest,
 	}
+	args = append(args, sshAuthArgs()...)
+	args = append(args, src, dest)
 	cmd := exec.Command(args[0], args[1:]...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/install/session.go
+++ b/install/session.go
@@ -3,8 +3,10 @@ package install
 import (
 	"context"
 	"io"
+	"os"
 	"os/exec"
 	"path/filepath"
+	"sync"
 
 	"github.com/cockroachdb/roachprod/config"
 )
@@ -28,14 +30,13 @@ type remoteSession struct {
 }
 
 func newRemoteSession(user, host string) (*remoteSession, error) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cmd := exec.CommandContext(ctx,
-		"ssh",
-		user+"@"+host,
-		"-i", filepath.Join(config.OSUser.HomeDir, ".ssh", "id_rsa"),
-		"-i", filepath.Join(config.OSUser.HomeDir, ".ssh", "google_compute_engine"),
+	args := []string{
+		user + "@" + host,
 		"-o", "StrictHostKeyChecking=no",
-	)
+	}
+	args = append(args, sshAuthArgs()...)
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := exec.CommandContext(ctx, "ssh", args...)
 	return &remoteSession{cmd, cancel}, nil
 }
 
@@ -139,4 +140,22 @@ func (s *localSession) RequestPty() error {
 func (s *localSession) Close() error {
 	s.cancel()
 	return nil
+}
+
+var sshAuthArgsVal []string
+var sshAuthArgsOnce sync.Once
+
+func sshAuthArgs() []string {
+	sshAuthArgsOnce.Do(func() {
+		paths := []string{
+			filepath.Join(config.OSUser.HomeDir, ".ssh", "id_rsa"),
+			filepath.Join(config.OSUser.HomeDir, ".ssh", "google_compute_engine"),
+		}
+		for _, p := range paths {
+			if _, err := os.Stat(p); err == nil {
+				sshAuthArgsVal = append(sshAuthArgsVal, "-i", p)
+			}
+		}
+	})
+	return sshAuthArgsVal
 }


### PR DESCRIPTION
Ssh does not like a `-i` flag specifying a file which do not exist.

Fixes #223

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/225)
<!-- Reviewable:end -->
