### PR TITLE
Pass -q to ssh

### DIFF
--- a/install/cluster_synced.go
+++ b/install/cluster_synced.go
@@ -1039,6 +1039,7 @@ func (c *SyncedCluster) Ssh(sshArgs, args []string) error {
 		allArgs = []string{
 			"ssh",
 			fmt.Sprintf("%s@%s", c.user(c.Nodes[0]), c.host(c.Nodes[0])),
+			"-o", "UserKnownHostsFile=/dev/null",
 			"-o", "StrictHostKeyChecking=no",
 		}
 		allArgs = append(allArgs, sshAuthArgs()...)

--- a/install/session.go
+++ b/install/session.go
@@ -32,6 +32,7 @@ type remoteSession struct {
 func newRemoteSession(user, host string) (*remoteSession, error) {
 	args := []string{
 		user + "@" + host,
+		"-q",
 		"-o", "UserKnownHostsFile=/dev/null",
 		"-o", "StrictHostKeyChecking=no",
 	}


### PR DESCRIPTION
Without this change,

https://github.com/cockroachdb/roachprod/blob/179f76e1d9d4d942358cb2d39ae9bcc9b05b0e33/install/cluster_synced.go#L104-L105

will print

> Warning: Permanently added 'x.x.x.x' (ECDSA) to the'list of known hosts.

into the output and the command will barf. We could get around it by only
grabbing stdout, but it doesn't seem that these warnings are welcome
anywhere in our roachprod usage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/229)
<!-- Reviewable:end -->
