### PR TITLE
Bump file descriptor limit on AWS

### DIFF
--- a/vm/aws/support.go
+++ b/vm/aws/support.go
@@ -44,6 +44,10 @@ echo -e "\nmakestep 0.1 3" | sudo tee -a /etc/chrony/chrony.conf
 sudo /etc/init.d/chrony restart
 sudo chronyc -a waitsync 30 0.01 | sudo tee -a /root/chrony.log
 
+# increase the default maximum number of open file descriptors for
+# root and non-root users. Load generators running a lot of concurrent
+# workers bump into this often.
+sudo sh -c 'echo "root - nofile 65536\n* - nofile 65536" > /etc/security/limits.d/10-roachprod-nofiles.conf'
 sudo touch /mnt/data1/.roachprod-initialized
 `
 


### PR DESCRIPTION
Copied from `vm/gce/utils.go`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/232)
<!-- Reviewable:end -->
