### PR TITLE
Introduce a --local-ssd-no-ext4-barrier flag for create

### DIFF
--- a/main.go
+++ b/main.go
@@ -1277,8 +1277,12 @@ func main() {
 
 	createCmd.Flags().DurationVarP(&createVMOpts.Lifetime,
 		"lifetime", "l", 12*time.Hour, "Lifetime of the cluster")
-	createCmd.Flags().BoolVar(&createVMOpts.UseLocalSSD,
+	createCmd.Flags().BoolVar(&createVMOpts.SSDOpts.UseLocalSSD,
 		"local-ssd", true, "Use local SSD")
+	createCmd.Flags().BoolVar(&createVMOpts.SSDOpts.NoExt4Barrier,
+		"local-ssd-no-ext4-barrier", false,
+		`Mount the local SSD with the "-o nobarrier" flag. `+
+			`Ignored if --local-ssd=false is specified.`)
 	createCmd.Flags().IntVarP(&numNodes,
 		"nodes", "n", 4, "Total number of nodes, distributed across all clouds")
 	createCmd.Flags().StringSliceVarP(&createVMOpts.VMProviders,

--- a/vm/aws/aws.go
+++ b/vm/aws/aws.go
@@ -480,7 +480,7 @@ func (p *Provider) runInstance(name string, zone string, opts vm.CreateOpts) err
 	}
 
 	var machineType string
-	if opts.UseLocalSSD {
+	if opts.SSDOpts.UseLocalSSD {
 		machineType = p.opts.SSDMachineType
 	} else {
 		machineType = p.opts.MachineType
@@ -534,7 +534,7 @@ func (p *Provider) runInstance(name string, zone string, opts vm.CreateOpts) err
 	}
 
 	// The local NVMe devices are automatically mapped.  Otherwise, we need to map an EBS data volume.
-	if !opts.UseLocalSSD {
+	if !opts.SSDOpts.UseLocalSSD {
 		args = append(args,
 			"--block-device-mapping",
 			// Size is measured in GB.  gp2 type derives guaranteed iops from size.

--- a/vm/gce/utils.go
+++ b/vm/gce/utils.go
@@ -2,13 +2,22 @@ package gce
 
 import (
 	"io/ioutil"
+	"text/template"
 )
 
 // Startup script used to find/format/mount all local SSDs in GCE.
 // Each disk is mounted to /mnt/data<disknum> and chmoded to all users.
-const gceLocalSSDStartupScript = `#!/usr/bin/env bash
+//
+// This is a template because the instantiator needs to optionally configure the
+// mounting options. The script cannot take arguments since it is to be invoked
+// by the gcloud tool which cannot pass args.
+const gceLocalSSDStartupScriptTemplate = `#!/usr/bin/env bash
+# Script for setting up a GCE machine for roachprod use.
+
+mount_opts="discard,defaults"
+{{if .ExtraMountOpts}}mount_opts="${mount_opts},{{.ExtraMountOpts}}"{{end}}
+
 disknum=0
-# Assume google.
 for d in $(ls /dev/disk/by-id/google-local-ssd-*); do
   let "disknum++"
   grep -e "${d}" /etc/fstab > /dev/null
@@ -17,8 +26,8 @@ for d in $(ls /dev/disk/by-id/google-local-ssd-*); do
     mountpoint="/mnt/data${disknum}"
     sudo mkdir -p "${mountpoint}"
     sudo mkfs.ext4 -F ${d}
-    sudo mount -o discard,defaults ${d} ${mountpoint}
-    echo "${d} ${mountpoint} ext4 discard,defaults 1 1" | sudo tee -a /etc/fstab
+    sudo mount -o ${mount_opts} ${d} ${mountpoint}
+    echo "${d} ${mountpoint} ext4 ${mount_opts} 1 1" | sudo tee -a /etc/fstab
   else
     echo "Disk ${disknum}: ${d} already mounted, skipping..."
   fi
@@ -48,17 +57,28 @@ EOF
 sysctl --system  # reload sysctl settings
 `
 
-// write the startup script to a temp file.
+// writeStartupScript writes the startup script to a temp file.
 // Returns the path to the file.
 // After use, the caller should delete the temp file.
-func writeStartupScript() (string, error) {
+//
+// extraMountOpts, if not empty, is appended to the default mount options. It is
+// a comma-separated list of options for the "mount -o" flag.
+func writeStartupScript(extraMountOpts string) (string, error) {
+
+	type tmplParams struct {
+		ExtraMountOpts string
+	}
+
+	args := tmplParams{ExtraMountOpts: extraMountOpts}
+
 	tmpfile, err := ioutil.TempFile("", "gce-startup-script")
 	if err != nil {
 		return "", err
 	}
 	defer tmpfile.Close()
 
-	if _, err := tmpfile.WriteString(gceLocalSSDStartupScript); err != nil {
+	t := template.Must(template.New("start").Parse(gceLocalSSDStartupScriptTemplate))
+	if err := t.Execute(tmpfile, args); err != nil {
 		return "", err
 	}
 	return tmpfile.Name(), nil

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -104,10 +104,15 @@ func (vl List) Zones() []string {
 
 // CreateOpts is the set of options when creating VMs.
 type CreateOpts struct {
-	UseLocalSSD    bool
 	Lifetime       time.Duration
 	GeoDistributed bool
 	VMProviders    []string
+	SSDOpts        struct {
+		UseLocalSSD bool
+		// NoExt4Barrier, if set, makes the "-o nobarrier" flag be used when
+		// mounting the SSD. Ignored if UseLocalSSD is not set.
+		NoExt4Barrier bool
+	}
 }
 
 // A hook point for Providers to supply additional, provider-specific flags to various


### PR DESCRIPTION
Use of nobarrier is common for roachprod clusters. They might even
become the default for roachtest clusters. This patch bring first-class
support for them into roachprod, which learns to mount a drive
accrdingly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/237)
<!-- Reviewable:end -->
