### PR TITLE
Correctly format single SSD on AWS

### DIFF
--- a/vm/aws/support.go
+++ b/vm/aws/support.go
@@ -36,10 +36,11 @@ if [ "${#disks[@]}" -eq "0" ]; then
 elif [ "${#disks[@]}" -eq "1" ]; then
   echo "One disk mounted, creating ${mountpoint}"
   mkdir -p ${mountpoint}
-  mkfs.ext4 -E nodiscard ${disks[1]}
-  mount -o discard,defaults ${disks[1]} ${mountpoint}
+  disk=${disks[0]}
+  mkfs.ext4 -E nodiscard ${disk}
+  mount -o discard,defaults ${disk} ${mountpoint}
   chmod 777 ${mountpoint}
-  echo "${disks[1]} ${mountpoint} ext4 discard,defaults 1 1" | tee -a /etc/fstab
+  echo "${disk} ${mountpoint} ext4 discard,defaults 1 1" | tee -a /etc/fstab
 else
   echo "${#disks[@]} disks mounted, creating ${mountpoint} using RAID 0"
   mkdir -p ${mountpoint}


### PR DESCRIPTION
Bash uses zero-indexed arrays, not one-indexed arrays (unlike most
shells https://unix.stackexchange.com/a/252405). This was mixed up
in the AWS startup script, causing tests on small machines with only
a single SSD to fail.

This commit fixes the bug. I verified that `kv0/encrypt=false/nodes=1`
passes again now without issue on AWS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/roachprod/239)
<!-- Reviewable:end -->
